### PR TITLE
로그아웃 테스트 코드 작성 + custom exception 처리

### DIFF
--- a/src/main/java/com/ctrls/auto_enter_view/service/CommonUserService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/CommonUserService.java
@@ -10,6 +10,7 @@ import com.ctrls.auto_enter_view.component.MailComponent;
 import com.ctrls.auto_enter_view.dto.common.SignInDto;
 import com.ctrls.auto_enter_view.entity.CandidateEntity;
 import com.ctrls.auto_enter_view.entity.CompanyEntity;
+import com.ctrls.auto_enter_view.enums.ErrorCode;
 import com.ctrls.auto_enter_view.exception.CustomException;
 import com.ctrls.auto_enter_view.repository.CandidateRepository;
 import com.ctrls.auto_enter_view.repository.CompanyRepository;
@@ -184,7 +185,7 @@ public class CommonUserService {
         String token = jwtTokenProvider.generateToken(company.getEmail(), company.getRole());
         return SignInDto.fromCompany(company, token);
       } else {
-        throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+        throw new CustomException(ErrorCode.PASSWORD_NOT_MATCH);
       }
     }
 
@@ -195,12 +196,12 @@ public class CommonUserService {
         String token = jwtTokenProvider.generateToken(candidate.getEmail(), candidate.getRole());
         return SignInDto.fromCandidate(candidate, token);
       } else {
-        throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+        throw new CustomException(ErrorCode.PASSWORD_NOT_MATCH);
       }
     }
 
     // 이메일이 존재하지 않는 경우
-    throw new RuntimeException("가입된 정보가 없습니다.");
+    throw new CustomException(USER_NOT_FOUND);
   }
 
   // 로그 아웃

--- a/src/test/java/com/ctrls/auto_enter_view/service/BlacklistTokenServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/BlacklistTokenServiceTest.java
@@ -1,0 +1,65 @@
+package com.ctrls.auto_enter_view.service;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+
+class BlacklistTokenServiceTest {
+
+  @Mock
+  private RedisTemplate<String, String> redisTemplate;
+
+  @Mock
+  private ValueOperations<String, String> valueOperations;
+
+  @InjectMocks
+  private BlacklistTokenService blacklistTokenService;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+  }
+
+  @Test
+  @DisplayName("블랙리스트에 토큰 추가 테스트")
+  void addToBlacklist() {
+    // given
+    String token = "Bearer testToken";
+    String substringToken = "testToken";
+    doNothing().when(valueOperations).set(substringToken, "logout", 60, TimeUnit.MINUTES);
+
+    // when
+    blacklistTokenService.addToBlacklist(token);
+
+    // then
+    verify(valueOperations, times(1)).set(substringToken, "logout", 60, TimeUnit.MINUTES);
+  }
+
+  @Test
+  @DisplayName("블랙리스트에 토큰 존재여부 확인 테스트")
+  void isTokenBlacklist() {
+    // given
+    String token = "testToken";
+    when(valueOperations.get(token)).thenReturn("logout");
+
+    // when
+    boolean isBlacklist = blacklistTokenService.isTokenBlacklist(token);
+
+    // then
+    assertTrue(isBlacklist);
+    verify(valueOperations, times(1)).get(token);
+  }
+}

--- a/src/test/java/com/ctrls/auto_enter_view/service/CommonUserServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/CommonUserServiceTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;

--- a/src/test/java/com/ctrls/auto_enter_view/service/CommonUserServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/CommonUserServiceTest.java
@@ -18,7 +18,9 @@ import com.ctrls.auto_enter_view.component.MailComponent;
 import com.ctrls.auto_enter_view.dto.common.SignInDto;
 import com.ctrls.auto_enter_view.entity.CandidateEntity;
 import com.ctrls.auto_enter_view.entity.CompanyEntity;
+import com.ctrls.auto_enter_view.enums.ErrorCode;
 import com.ctrls.auto_enter_view.enums.UserRole;
+import com.ctrls.auto_enter_view.exception.CustomException;
 import com.ctrls.auto_enter_view.repository.CandidateRepository;
 import com.ctrls.auto_enter_view.repository.CompanyRepository;
 import com.ctrls.auto_enter_view.security.JwtTokenProvider;
@@ -57,6 +59,9 @@ class CommonUserServiceTest {
 
   @Mock
   private JwtTokenProvider jwtTokenProvider;
+
+  @Mock
+  private BlacklistTokenService blacklistTokenService;
 
   @InjectMocks
   private CommonUserService commonUserService;
@@ -323,5 +328,20 @@ class CommonUserServiceTest {
 
     // then
     assertEquals("가입된 정보가 없습니다.", exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("로그아웃 테스트")
+  void logoutUser() {
+    // given
+    String token = "testToken";
+    // 실제로 동작하지 않아도 됨
+    doNothing().when(blacklistTokenService).addToBlacklist(token);
+
+    // when
+    commonUserService.logoutUser(token);
+
+    // then
+    verify(blacklistTokenService, times(1)).addToBlacklist(token);
   }
 }


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 로그인 서비스 코드에서 Custom 예외 처리가 안되어있음
- 로그아웃 기능의 테스트 코드가  없음
 
**TO-BE**
- 비밀번호가 일치하지 않을 때 Custom Exception 처리로 변경
- 이메일이 존재하지 않을 때 Custom Exception 처리로 변경
- 로그아웃 기능과 블랙 리스트 관련 테스트 코드 추가 

### 테스트
- 로그아웃 기능 테스트는 블랙리스트에 토큰을 넣어주는 메서드가 호출되는지 여부를 확인
- 블랙 리스트에 토큰이 들어가는지 테스트 진행
- 블랙 리스트에 존재하는 토큰인지 확인하는 테스트 진행
