### PR TITLE
채용공고 업데이트 / 삭제 기능 추가

### DIFF
--- a/src/main/java/com/ctrls/auto_enter_view/controller/JobPostingController.java
+++ b/src/main/java/com/ctrls/auto_enter_view/controller/JobPostingController.java
@@ -7,9 +7,12 @@ import com.ctrls.auto_enter_view.service.JobPostingStepService;
 import com.ctrls.auto_enter_view.service.JobPostingTechStackService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -35,4 +38,28 @@ public class JobPostingController {
 
     return ResponseEntity.ok("jobPostingKey: " + jobPosting.getJobPostingKey());
   }
+
+  @PutMapping("/job-postings/{jobPostingKey}")
+  public ResponseEntity<String> editJobPosting(@PathVariable String jobPostingKey,
+      @RequestBody @Validated JobPostingDto.Request request) {
+
+    jobPostingService.editJobPosting(jobPostingKey, request);
+    jobPostingTechStackService.editJobPostingTechStack(jobPostingKey, request);
+    jobPostingStepService.editJobPostingStep(jobPostingKey, request);
+
+    return ResponseEntity.ok("수정 완료");
+  }
+
+  @Transactional
+  @DeleteMapping("/job-postings/{jobPostingKey}")
+  public ResponseEntity<String> deleteJobPosting(@PathVariable String jobPostingKey) {
+
+    jobPostingService.deleteJobPosting(jobPostingKey);
+    jobPostingTechStackService.deleteJobPostingTechStack(jobPostingKey);
+    jobPostingStepService.deleteJobPostingStep(jobPostingKey);
+
+    return ResponseEntity.ok("삭제 완료");
+  }
+
+
 }

--- a/src/main/java/com/ctrls/auto_enter_view/dto/jobposting/JobPostingDto.java
+++ b/src/main/java/com/ctrls/auto_enter_view/dto/jobposting/JobPostingDto.java
@@ -92,9 +92,26 @@ public class JobPostingDto extends BaseEntity {
 
     }
 
+    public static JobPostingTechStackEntity toTechStackEntity(String jobPostingKey,
+        String techName) {
+
+      return JobPostingTechStackEntity.builder()
+          .jobPostingKey(jobPostingKey)
+          .techName(techName)
+          .build();
+
+    }
+
     public static JobPostingStepEntity toStepEntity(JobPostingEntity entity, String stepName) {
       return JobPostingStepEntity.builder()
           .jobPostingKey(entity.getJobPostingKey())
+          .step(stepName)
+          .build();
+    }
+
+    public static JobPostingStepEntity toStepEntity(String jobPostingKey, String stepName) {
+      return JobPostingStepEntity.builder()
+          .jobPostingKey(jobPostingKey)
           .step(stepName)
           .build();
     }

--- a/src/main/java/com/ctrls/auto_enter_view/entity/BaseEntity.java
+++ b/src/main/java/com/ctrls/auto_enter_view/entity/BaseEntity.java
@@ -1,12 +1,16 @@
 package com.ctrls.auto_enter_view.entity;
 
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
 public class BaseEntity {
 
   @CreatedDate

--- a/src/main/java/com/ctrls/auto_enter_view/entity/JobPostingEntity.java
+++ b/src/main/java/com/ctrls/auto_enter_view/entity/JobPostingEntity.java
@@ -1,5 +1,6 @@
 package com.ctrls.auto_enter_view.entity;
 
+import com.ctrls.auto_enter_view.dto.jobposting.JobPostingDto.Request;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
@@ -52,4 +53,19 @@ public class JobPostingEntity extends BaseEntity {
   private LocalDate endDate;
 
   private String jobPostingContent;
+
+  public void updateEntity(Request request) {
+    this.title = request.getTitle();
+    this.jobCategory = request.getJobCategory();
+    this.career = request.getCareer();
+    this.workLocation = request.getWorkLocation();
+    this.education = request.getEducation();
+    this.employmentType = request.getEmploymentType();
+    this.salary = request.getSalary();
+    this.workTime = request.getWorkTime();
+    this.startDate = request.getStartDate();
+    this.endDate = request.getEndDate();
+    this.jobPostingContent = request.getJobPostingContent();
+  }
+
 }

--- a/src/main/java/com/ctrls/auto_enter_view/entity/JobPostingStepEntity.java
+++ b/src/main/java/com/ctrls/auto_enter_view/entity/JobPostingStepEntity.java
@@ -22,9 +22,13 @@ public class JobPostingStepEntity extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
-  
+
   @Column(nullable = false)
   private String jobPostingKey;
 
   private String step;
+
+  public void updateEntity(String step) {
+    this.step = step;
+  }
 }

--- a/src/main/java/com/ctrls/auto_enter_view/entity/JobPostingTechStackEntity.java
+++ b/src/main/java/com/ctrls/auto_enter_view/entity/JobPostingTechStackEntity.java
@@ -28,4 +28,8 @@ public class JobPostingTechStackEntity extends BaseEntity {
 
   @Column(nullable = false)
   private String techName;
+
+  public void updateEntity(String techName) {
+    this.techName = techName;
+  }
 }

--- a/src/main/java/com/ctrls/auto_enter_view/repository/JobPostingRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/JobPostingRepository.java
@@ -5,4 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JobPostingRepository extends JpaRepository<JobPostingEntity, String> {
 
+  JobPostingEntity findByJobPostingKey(String jobPostingKey);
+
+  void deleteByJobPostingKey(String jobPostingKey);
 }

--- a/src/main/java/com/ctrls/auto_enter_view/repository/JobPostingStepRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/JobPostingStepRepository.java
@@ -1,10 +1,14 @@
 package com.ctrls.auto_enter_view.repository;
 
 import com.ctrls.auto_enter_view.entity.JobPostingStepEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface JobPostingStepRepository extends JpaRepository<JobPostingStepEntity, Long> {
 
+  List<JobPostingStepEntity> findByJobPostingKey(String jobPostingKey);
+
+  void deleteByJobPostingKey(String jobPostingKey);
 }

--- a/src/main/java/com/ctrls/auto_enter_view/repository/JobPostingTechStackRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/JobPostingTechStackRepository.java
@@ -1,9 +1,13 @@
 package com.ctrls.auto_enter_view.repository;
 
 import com.ctrls.auto_enter_view.entity.JobPostingTechStackEntity;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JobPostingTechStackRepository extends
     JpaRepository<JobPostingTechStackEntity, Long> {
 
+  List<JobPostingTechStackEntity> findByJobPostingKey(String jobPostingKey);
+
+  void deleteByJobPostingKey(String jobPostingKey);
 }

--- a/src/main/java/com/ctrls/auto_enter_view/service/JobPostingService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/JobPostingService.java
@@ -21,5 +21,15 @@ public class JobPostingService {
     return jobPostingRepository.save(entity);
   }
 
+  public void editJobPosting(String jobPostingKey, Request request) {
 
+    JobPostingEntity entity = jobPostingRepository.findByJobPostingKey(jobPostingKey);
+    entity.updateEntity(request);
+
+  }
+
+
+  public void deleteJobPosting(String jobPostingKey) {
+    jobPostingRepository.deleteByJobPostingKey(jobPostingKey);
+  }
 }

--- a/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
@@ -31,5 +31,26 @@ public class JobPostingStepService {
 
   }
 
+  public void editJobPostingStep(String jobPostingKey, JobPostingDto.Request request) {
 
+    List<JobPostingStepEntity> entities = jobPostingStepRepository.findByJobPostingKey(
+        jobPostingKey);
+
+    jobPostingStepRepository.deleteAll(entities);
+
+    List<String> jobPostingStep = request.getJobPostingStep();
+
+    List<JobPostingStepEntity> jobPostingStepEntities = jobPostingStep.stream()
+        .map(e -> Request.toStepEntity(jobPostingKey, e))
+        .toList();
+
+    jobPostingStepRepository.saveAll(jobPostingStepEntities);
+
+
+  }
+
+  public void deleteJobPostingStep(String jobPostingKey) {
+    jobPostingStepRepository.deleteByJobPostingKey(jobPostingKey);
+
+  }
 }

--- a/src/main/java/com/ctrls/auto_enter_view/service/JobPostingTechStackService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/JobPostingTechStackService.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.orm.jpa.support.OpenEntityManagerInViewInterceptor;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Service;
 public class JobPostingTechStackService {
 
   private final JobPostingTechStackRepository jobPostingTechStackRepository;
+  private final OpenEntityManagerInViewInterceptor openEntityManagerInViewInterceptor;
 
   public void createJobPostingTechStack(JobPostingEntity jobPostingEntity,
       JobPostingDto.Request request) {
@@ -29,5 +31,27 @@ public class JobPostingTechStackService {
 
     jobPostingTechStackRepository.saveAll(entities);
 
+  }
+
+  public void editJobPostingTechStack(String jobPostingKey, JobPostingDto.Request request) {
+
+    List<JobPostingTechStackEntity> entities = jobPostingTechStackRepository.findByJobPostingKey(
+        jobPostingKey);
+
+    jobPostingTechStackRepository.deleteAll(entities);
+
+    List<String> techStack = request.getTechStack();
+
+    List<JobPostingTechStackEntity> techStackEntities = techStack.stream()
+        .map(e -> Request.toTechStackEntity(jobPostingKey, e))
+        .toList();
+
+    jobPostingTechStackRepository.saveAll(techStackEntities);
+
+  }
+
+
+  public void deleteJobPostingTechStack(String jobPostingKey) {
+    jobPostingTechStackRepository.deleteByJobPostingKey(jobPostingKey);
   }
 }

--- a/src/test/java/com/ctrls/auto_enter_view/testJobPosting.http
+++ b/src/test/java/com/ctrls/auto_enter_view/testJobPosting.http
@@ -1,6 +1,6 @@
 ### create job posting test
-POST http://localhost:8080/companies/31d3a87b11ff47119b853f08d2714e31/job-postings
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjb21wYW55QG5hdmVyLmNvbSIsInJvbGUiOiJST0xFX0NPTVBBTlkiLCJpYXQiOjE3MjA0MTY3NTMsImV4cCI6MTcyMDQyMDM1M30.GhOMQftHh9WT8-R-Qe4Q3Xn4-8I7i34sNnM_EkOYJtw
+POST http://localhost:8080/companies/c2f0003a1b1648f28583754fe9c90ac0/job-postings
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjb21wYW55QG5hdmVyLmNvbSIsInJvbGUiOiJST0xFX0NPTVBBTlkiLCJpYXQiOjE3MjA0MjYxNTQsImV4cCI6MTcyMDQyOTc1NH0.shOyF991AeE1cT13SlId5qC1fAJKL5JPbyLPb7cJvyM
 Content-Type: application/json
 
 {
@@ -24,3 +24,36 @@ Content-Type: application/json
   "endDate": "2023-03-15",
   "jobPostingContent": "내용"
 }
+
+
+### edit job posting test
+PUT http://localhost:8080/job-postings/79efcf5156714a4da28571a15b8890f4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjb21wYW55QG5hdmVyLmNvbSIsInJvbGUiOiJST0xFX0NPTVBBTlkiLCJpYXQiOjE3MjA0MjYxNTQsImV4cCI6MTcyMDQyOTc1NH0.shOyF991AeE1cT13SlId5qC1fAJKL5JPbyLPb7cJvyM
+Content-Type: application/json
+
+{
+  "title": "공고제목 수정",
+  "jobCategory": "백엔드",
+  "career": "3",
+  "techStack": [
+    "JAVA",
+    "SPRING",
+    "Node.js"
+  ],
+  "jobPostingStep": [
+    "서류"
+  ],
+  "workLocation": "서울특별시",
+  "education": "4년제",
+  "employmentType": "비정규직",
+  "salary": 3000,
+  "workTime": "09:00 ~ 15:00",
+  "startDate": "2023-03-05",
+  "endDate": "2023-03-15",
+  "jobPostingContent": "내용"
+}
+
+
+### delete job posting test
+DELETE http://localhost:8080/job-postings/79efcf5156714a4da28571a15b8890f4
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjb21wYW55QG5hdmVyLmNvbSIsInJvbGUiOiJST0xFX0NPTVBBTlkiLCJpYXQiOjE3MjA0MjYxNTQsImV4cCI6MTcyMDQyOTc1NH0.shOyF991AeE1cT13SlId5qC1fAJKL5JPbyLPb7cJvyM


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- JobPostingController 에 채용 공고를 수정하는 API가 없었습니다.

- JobPostingController 에 채용 공고를 삭제하는 API가 없었습니다.

- 채용 공고를 수정 할 때, JobPostingDto의 Request 클래스에서 JobPostingKey를 통한 entity반환 매서드가 없었습니다.


**TO-BE**
- JobPostingController 에 채용 공고를 수정하는 PUT 매서드를 추가 하였습니다.

- JobPostingController 에 채용 공고를 삭제하는 Delete 매서드를 추가 하였습니다.

- 채용 공고 수정시에  JobPostingDto의 Request 클래스에서 JobPostingKey를 통해 JobPostingTechStackEntity, JobPostingStepEntity를 반환하도록 기존의 매서드를 오버로딩 하였습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [x] API 테스트 