### PR TITLE
(공통) 채용 공고 상세 정보 조회 기능

### DIFF
--- a/src/main/java/com/ctrls/auto_enter_view/controller/CommonJobPostingController.java
+++ b/src/main/java/com/ctrls/auto_enter_view/controller/CommonJobPostingController.java
@@ -1,15 +1,17 @@
 package com.ctrls.auto_enter_view.controller;
 
+import com.ctrls.auto_enter_view.dto.common.JobPostingDetailDto;
 import com.ctrls.auto_enter_view.dto.common.MainJobPostingDto;
 import com.ctrls.auto_enter_view.service.JobPostingService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@RequestMapping("/common")
+@RequestMapping("/common/job-postings")
 @RequiredArgsConstructor
 @RestController
 public class CommonJobPostingController {
@@ -17,10 +19,19 @@ public class CommonJobPostingController {
   private final JobPostingService jobPostingService;
 
   // main 화면에 보여질 채용 공고 가져오기
-  @GetMapping("/job-postings")
-  public ResponseEntity<List<MainJobPostingDto.Response>> findAllJobPosting() {
+  @GetMapping
+  public ResponseEntity<List<MainJobPostingDto.Response>> getAllJobPosting() {
 
     List<MainJobPostingDto.Response> response = jobPostingService.getAllJobPosting();
+    return ResponseEntity.ok(response);
+  }
+
+  // 채용 공고 상세 정보 가져오기
+  @GetMapping("/{jobPostingKey}")
+  public ResponseEntity<JobPostingDetailDto.Response> getDetailJobPosting(
+      @PathVariable String jobPostingKey) {
+
+    JobPostingDetailDto.Response response = jobPostingService.getJobPostingDetail(jobPostingKey);
     return ResponseEntity.ok(response);
   }
 }

--- a/src/main/java/com/ctrls/auto_enter_view/dto/common/JobPostingDetailDto.java
+++ b/src/main/java/com/ctrls/auto_enter_view/dto/common/JobPostingDetailDto.java
@@ -1,0 +1,55 @@
+package com.ctrls.auto_enter_view.dto.common;
+
+import com.ctrls.auto_enter_view.entity.JobPostingEntity;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class JobPostingDetailDto {
+
+  @Getter
+  @AllArgsConstructor
+  @Builder
+  public static class Response {
+
+    private String jobPostingKey;
+    private String title;
+    private String jobCategory;
+    private Integer career;
+    private String workLocation;
+    private String education;
+    private String employmentType;
+    private Long salary;
+    private String workTime;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String jobPostingContent;
+
+    private List<String> techStack;
+    private List<String> step;
+
+
+    public static Response from(JobPostingEntity entity, List<String> techStack,
+        List<String> step) {
+
+      return Response.builder()
+          .jobPostingKey(entity.getJobPostingKey())
+          .title(entity.getTitle())
+          .jobCategory(entity.getJobCategory())
+          .career(entity.getCareer())
+          .workLocation(entity.getWorkLocation())
+          .education(entity.getEducation())
+          .employmentType(entity.getEmploymentType())
+          .salary(entity.getSalary())
+          .workTime(entity.getWorkTime())
+          .startDate(entity.getStartDate())
+          .endDate(entity.getEndDate())
+          .jobPostingContent(entity.getJobPostingContent())
+          .techStack(techStack)
+          .step(step)
+          .build();
+    }
+  }
+}

--- a/src/main/java/com/ctrls/auto_enter_view/dto/common/JobPostingDetailDto.java
+++ b/src/main/java/com/ctrls/auto_enter_view/dto/common/JobPostingDetailDto.java
@@ -15,6 +15,7 @@ public class JobPostingDetailDto {
   public static class Response {
 
     private String jobPostingKey;
+    private String companyKey;
     private String title;
     private String jobCategory;
     private Integer career;
@@ -36,6 +37,7 @@ public class JobPostingDetailDto {
 
       return Response.builder()
           .jobPostingKey(entity.getJobPostingKey())
+          .companyKey(entity.getCompanyKey())
           .title(entity.getTitle())
           .jobCategory(entity.getJobCategory())
           .career(entity.getCareer())

--- a/src/main/java/com/ctrls/auto_enter_view/service/JobPostingService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/JobPostingService.java
@@ -2,9 +2,9 @@ package com.ctrls.auto_enter_view.service;
 
 import static com.ctrls.auto_enter_view.enums.ErrorCode.USER_NOT_FOUND;
 
+import com.ctrls.auto_enter_view.dto.common.JobPostingDetailDto;
 import com.ctrls.auto_enter_view.dto.common.MainJobPostingDto;
 import com.ctrls.auto_enter_view.dto.common.MainJobPostingDto.JobPostingMainInfo;
-import com.ctrls.auto_enter_view.dto.common.MainJobPostingDto.Response;
 import com.ctrls.auto_enter_view.dto.jobPosting.JobPostingDto.Request;
 import com.ctrls.auto_enter_view.dto.jobPosting.JobPostingInfoDto;
 import com.ctrls.auto_enter_view.entity.CompanyEntity;
@@ -31,6 +31,7 @@ public class JobPostingService {
   private final JobPostingRepository jobPostingRepository;
   private final CompanyRepository companyRepository;
   private final JobPostingTechStackService jobPostingTechStackService;
+  private final JobPostingStepService jobPostingStepService;
 
   public JobPostingEntity createJobPosting(String companyKey, Request request) {
 
@@ -95,30 +96,17 @@ public class JobPostingService {
     entity.get().updateEntity(request);
   }
 
-  public List<Response> getAllJobPosting() {
-
+  // Main 화면 채용 공고 조회
+  public List<MainJobPostingDto.Response> getAllJobPosting() {
     List<JobPostingEntity> jobPostingEntities = jobPostingRepository.findAll();
-    List<Response> responseList = new ArrayList<>();
+    List<MainJobPostingDto.Response> responseList = new ArrayList<>();
 
     for (JobPostingEntity entity : jobPostingEntities) {
-      String companyKey = entity.getCompanyKey();
-      CompanyEntity companyEntity = companyRepository.findByCompanyKey(companyKey)
-          .orElseThrow(() -> new CustomException(ErrorCode.COMPANY_NOT_FOUND));
-
-      String companyName = companyEntity.getCompanyName();
-      log.info("회사명 조회 완료 : {}", companyName);
-
-      String jobPostingKey = entity.getJobPostingKey();
-      List<String> techStack = jobPostingTechStackService.getTechStackByJobPostingKey(
-          jobPostingKey);
-
-      JobPostingMainInfo jobPostingMainInfo = JobPostingMainInfo.from(entity, companyName,
-          techStack);
+      JobPostingMainInfo jobPostingMainInfo = createJobPostingMainInfo(entity);
 
       MainJobPostingDto.Response response = MainJobPostingDto.Response.builder()
           .jobPostingsList(List.of(jobPostingMainInfo))
           .build();
-
       responseList.add(response);
     }
 
@@ -126,8 +114,53 @@ public class JobPostingService {
     return responseList;
   }
 
+  // 채용 공고 상세 보기
+  public JobPostingDetailDto.Response getJobPostingDetail(String jobPostingKey) {
+    JobPostingEntity jobPosting = jobPostingRepository.findByJobPostingKey(jobPostingKey)
+        .orElseThrow(() -> new CustomException(ErrorCode.JOB_POSTING_NOT_FOUND));
+
+    List<String> techStack = getTechStack(jobPosting.getJobPostingKey());
+    List<String> step = getStep(jobPosting.getJobPostingKey());
+
+    return JobPostingDetailDto.Response.from(jobPosting, techStack, step);
+  }
+
+  // 전체 체용 공고 List 들어갈 정보
+  private JobPostingMainInfo createJobPostingMainInfo(JobPostingEntity entity) {
+    String companyName = getCompanyName(entity.getCompanyKey());
+    List<String> techStack = getTechStack(entity.getJobPostingKey());
+
+    return JobPostingMainInfo.from(entity, companyName, techStack);
+  }
+
+  // 회사 이름 가져오기
+  private String getCompanyName(String companyKey) {
+    CompanyEntity companyEntity = companyRepository.findByCompanyKey(companyKey)
+        .orElseThrow(() -> new CustomException(ErrorCode.COMPANY_NOT_FOUND));
+
+    String companyName = companyEntity.getCompanyName();
+    log.info("회사명 조회 완료 : {}", companyName);
+    return companyName;
+  }
+
+  // 기술 스택 가져오기
+  private List<String> getTechStack(String jobPostingKey) {
+    List<String> techStack = jobPostingTechStackService.getTechStackByJobPostingKey(jobPostingKey);
+    log.info("기술 스택 조회 완료 : {}", techStack);
+    return techStack;
+  }
+
+  // 채용 일정 가져오기
+  private List<String> getStep(String jobPostingKey) {
+    List<String> step = jobPostingStepService.getStepByJobPostingKey(jobPostingKey);
+    log.info("채용 단계 조회 완료 : {}", step);
+    return step;
+  }
+
+
   public void deleteJobPosting(String jobPostingKey) {
 
     jobPostingRepository.deleteByJobPostingKey(jobPostingKey);
   }
+
 }

--- a/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
@@ -23,6 +23,7 @@ import com.ctrls.auto_enter_view.repository.JobPostingRepository;
 import com.ctrls.auto_enter_view.repository.JobPostingStepRepository;
 import com.ctrls.auto_enter_view.repository.ResumeRepository;
 import com.ctrls.auto_enter_view.repository.ResumeTechStackRepository;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -196,4 +197,17 @@ public class JobPostingStepService {
 
     jobPostingStepRepository.deleteByJobPostingKey(jobPostingKey);
   }
+
+  // 채용 공고 key -> 채용 단계 조회
+  public List<String> getStepByJobPostingKey(String jobPostingKey) {
+    List<JobPostingStepEntity> entities = jobPostingStepRepository.findByJobPostingKey(jobPostingKey);
+    List<String> step = new ArrayList<>();
+
+    for (JobPostingStepEntity entity : entities) {
+      step.add(entity.getStep());
+    }
+    log.info("step 가져오기 성공 {}", step);
+    return step;
+  }
+
 }

--- a/src/main/java/com/ctrls/auto_enter_view/service/JobPostingTechStackService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/JobPostingTechStackService.java
@@ -31,6 +31,7 @@ public class JobPostingTechStackService {
     jobPostingTechStackRepository.saveAll(entities);
   }
 
+  // 채용 공고 key -> 기술 스택 조회
   public List<String> getTechStackByJobPostingKey(String jobPostingKey) {
 
     List<JobPostingTechStackEntity> entities = jobPostingTechStackRepository.findByJobPostingKey(


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 채용 공고 상세 정보 조회 기능 없음
- 채용 공고 단계 정보 조회 기능 없음

**TO-BE**
- 채용 공고 상세 정보 조회 API 추가
: CommonJobPostirngController에  ```@RequestMapping("/common/job-postings")``` 추가
채용 공고 키를 PathVariable로 받아서 상세 정보 조회

- 채용 공고 상세 정보 DTO 생성 (Response)
: 채용 공고 Entity + 기술 스택 + 채용 단계 포함
⭐ 현재 이미지 추가 기능 구현 못함 ⭐ -  내일 공부 후 추가해볼 예정

- 전체 채용 공고 조회 메서드 리팩토링
: 채용공고 상세 조회 기능과 공통 로직이 있어서 수행
기술 스택 조회 기능을 getTechStack 메서드로 분리
자연스럽게 회사 이름 조회 기능, 채용 단계 조회 기능으로 분리
전체 채용 공고 정보는 List로 반환해야해서 createJobPostingMainInfo 메서드로 정보 생성

- 채용 공고 키로 채용 단계 조회 기능 구현
: 채용 공고 키로 관련된 채용 단계 엔티티 조회
조회된 엔티티에서 단계 정보를 List<String>에 저장

