### PR TITLE
(지원자) 채용 공고 지원하기

### DIFF
--- a/src/main/java/com/ctrls/auto_enter_view/controller/JobPostingController.java
+++ b/src/main/java/com/ctrls/auto_enter_view/controller/JobPostingController.java
@@ -3,12 +3,16 @@ package com.ctrls.auto_enter_view.controller;
 import com.ctrls.auto_enter_view.dto.jobPosting.JobPostingDto;
 import com.ctrls.auto_enter_view.dto.jobPosting.JobPostingInfoDto;
 import com.ctrls.auto_enter_view.entity.JobPostingEntity;
+import com.ctrls.auto_enter_view.enums.ResponseMessage;
+import com.ctrls.auto_enter_view.service.CandidateService;
 import com.ctrls.auto_enter_view.service.JobPostingService;
 import com.ctrls.auto_enter_view.service.JobPostingStepService;
 import com.ctrls.auto_enter_view.service.JobPostingTechStackService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -28,6 +32,8 @@ public class JobPostingController {
   private final JobPostingTechStackService jobPostingTechStackService;
 
   private final JobPostingStepService jobPostingStepService;
+
+  private final CandidateService candidateService;
 
   @PostMapping("/companies/{companyKey}/job-postings")
   public ResponseEntity<String> createJobPosting(@PathVariable String companyKey,
@@ -75,5 +81,19 @@ public class JobPostingController {
     jobPostingStepService.deleteJobPostingStep(jobPostingKey);
 
     return ResponseEntity.ok("삭제 완료");
+  }
+
+  // (지원자) 채용 공고 지원하기
+  @PostMapping("/candidate/job-postings/{jobPostingKey}/apply")
+  public ResponseEntity<?> applyJobPosting(
+      @PathVariable String jobPostingKey,
+      @AuthenticationPrincipal UserDetails userDetails) {
+
+    String candidateEmail = userDetails.getUsername();
+    String candidateKey = candidateService.findCandidateKeyByEmail(candidateEmail);
+
+    jobPostingService.applyJobPosting(jobPostingKey, candidateKey);
+
+    return ResponseEntity.ok(ResponseMessage.SUCCESS_JOB_POSTING_APPLY.getMessage());
   }
 }

--- a/src/main/java/com/ctrls/auto_enter_view/enums/ErrorCode.java
+++ b/src/main/java/com/ctrls/auto_enter_view/enums/ErrorCode.java
@@ -9,6 +9,7 @@ public enum ErrorCode {
 
   AUTHENTICATION_FAILED(401, "사용자 인증에 실패했습니다."),
   COMPANY_NOT_FOUND(404, "가입된 회사를 찾을 수 없습니다."),
+  CANDIDATE_NOT_FOUND(404, "가입된 지원자를 찾을 수 없습니다."),
   EMAIL_DUPLICATION(400, "이메일이 중복됩니다."),
   EMAIL_NOT_FOUND(404, "가입된 사용자 이메일이 없습니다."),
   EMAIL_SEND_FAILURE(500, "이메일 전송에 실패했습니다."),
@@ -22,7 +23,8 @@ public enum ErrorCode {
   PASSWORD_NOT_MATCH(400, "비밀번호가 일치하지 않습니다"),
   RESUME_NOT_FOUND(404, "지원자의 이력서를 찾을 수 없습니다"),
   TOKEN_BLACKLISTED(401, "토큰이 블랙리스트에 존재하여 사용할 수 없는 토큰입니다."),
-  USER_NOT_FOUND(404, "사용자를 찾을 수 없습니다.");
+  USER_NOT_FOUND(404, "사용자를 찾을 수 없습니다."),
+  ALREADY_APPLIED(404, "이미 지원한 채용 공고입니다.");
 
   private final int status;
   private final String message;

--- a/src/main/java/com/ctrls/auto_enter_view/enums/ResponseMessage.java
+++ b/src/main/java/com/ctrls/auto_enter_view/enums/ResponseMessage.java
@@ -15,7 +15,8 @@ public enum ResponseMessage {
   SUCCESS_TEMPORARY_PASSWORD_SEND("임시 비밀번호 전송 성공."),
   SUCCESS_UPDATE_COMPANY_INFO("회사 정보 수정이 완료되었습니다."),
   USABLE_EMAIL("사용 가능한 이메일입니다."),
-  WITHDRAW("회원탈퇴 완료.");
+  WITHDRAW("회원탈퇴 완료."),
+  SUCCESS_JOB_POSTING_APPLY("지원이 완료되었습니다.");
 
   private final String message;
 }

--- a/src/main/java/com/ctrls/auto_enter_view/repository/CandidateListRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/CandidateListRepository.java
@@ -10,4 +10,6 @@ public interface CandidateListRepository extends JpaRepository<CandidateListEnti
 
   List<CandidateListEntity> findAllByJobPostingKeyAndJobPostingStepId(String jobPostingKey,
       Long jobPostingStepId);
+
+  boolean existsByCandidateKeyAndJobPostingKey(String candidateKey, String jobPostingKey);
 }

--- a/src/main/java/com/ctrls/auto_enter_view/repository/JobPostingRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/JobPostingRepository.java
@@ -14,4 +14,6 @@ public interface JobPostingRepository extends JpaRepository<JobPostingEntity, St
   List<JobPostingEntity> findAllByCompanyKey(String companyKey);
 
   void deleteByJobPostingKey(String jobPostingKey);
+
+  boolean existsByJobPostingKey(String jobPostingKey);
 }

--- a/src/main/java/com/ctrls/auto_enter_view/repository/JobPostingStepRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/JobPostingStepRepository.java
@@ -15,4 +15,6 @@ public interface JobPostingStepRepository extends JpaRepository<JobPostingStepEn
   List<JobPostingStepEntity> findByJobPostingKey(String jobPostingKey);
 
   void deleteByJobPostingKey(String jobPostingKey);
+
+  JobPostingStepEntity findFirstByJobPostingKeyOrderByIdAsc(String jobPostingKey);
 }

--- a/src/main/java/com/ctrls/auto_enter_view/service/CandidateService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/CandidateService.java
@@ -11,6 +11,7 @@ import com.ctrls.auto_enter_view.dto.candidate.FindEmailDto.Response;
 import com.ctrls.auto_enter_view.dto.candidate.SignUpDto;
 import com.ctrls.auto_enter_view.dto.candidate.WithdrawDto;
 import com.ctrls.auto_enter_view.entity.CandidateEntity;
+import com.ctrls.auto_enter_view.enums.ErrorCode;
 import com.ctrls.auto_enter_view.exception.CustomException;
 import com.ctrls.auto_enter_view.repository.CandidateRepository;
 import lombok.RequiredArgsConstructor;
@@ -100,5 +101,19 @@ public class CandidateService {
     return Response.builder()
         .email(candidateEntity.getEmail())
         .build();
+  }
+
+  // 로그인 한 지원자 email -> candidateKey 추출
+  public String findCandidateKeyByEmail(String candidateEmail) {
+    return candidateRepository.findByEmail(candidateEmail)
+        .map(CandidateEntity::getCandidateKey)
+        .orElseThrow(() -> new CustomException(EMAIL_NOT_FOUND));
+  }
+
+  // candidateKey -> 지원자 정보 조회
+  public String getCandidateNameByKey(String candidateKey) {
+    return candidateRepository.findByCandidateKey(candidateKey)
+        .map(CandidateEntity::getName)
+        .orElseThrow(() -> new CustomException(ErrorCode.CANDIDATE_NOT_FOUND));
   }
 }

--- a/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
@@ -52,7 +52,10 @@ public class JobPostingStepService {
         .map(e -> Request.toStepEntity(entity, e))
         .collect(Collectors.toList());
 
-    jobPostingStepRepository.saveAll(entities);
+    List<JobPostingStepEntity> savedEntities = jobPostingStepRepository.saveAll(entities);
+    log.info("Saved jobPostingSteps : {}", savedEntities.stream()
+        .map(e -> "id: " + e.getId() + ", step: " + e.getStep())
+        .collect(Collectors.toList()));
   }
 
   /**


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 채용 공고 지원 기능이 없음
- 채용 공고의 첫 번째 단계를 조회하는 기능이 없음

**TO-BE**

- [ ] 채용 공고 지원 기능 구현
- 로그인 한 지원자의 이메일로 candidateKey를 가져옴
- 지원할 채용 공고의 존재 여부를 확인 후 없으면 JOB_POSTING_NOT_FOUND 에러 발생
- candidateKey로 지원자의 이름을 가져옴
- 채용 공고의 채용 단계 중 첫번째 단계 ID 가져오기 : findFirstByJobPostingKeyOrderByIdAsc
- 지원자가 이미 지원한 채용 공고라면 candidateList에 존재하는지 확인하고, ALREADY_APPLIED 에러 발생


### 테스트
- [x] API 테스트 