### PR TITLE
(지원자) 본인이 지원한 채용공고 리스트 조회

### DIFF
--- a/src/main/java/com/ctrls/auto_enter_view/controller/CandidateController.java
+++ b/src/main/java/com/ctrls/auto_enter_view/controller/CandidateController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -69,9 +70,12 @@ public class CandidateController {
 
   // (지원자) 지원한 채용 공고 조회하기
   @GetMapping("/candidates/{candidateKey}/applied-job-postings")
-  public ResponseEntity<CandidateApplyDto.Response> getApplyJobPosting(@PathVariable String candidateKey) {
+  public ResponseEntity<CandidateApplyDto.Response> getApplyJobPosting(
+      @PathVariable String candidateKey,
+      @RequestParam(defaultValue = "1") int page,
+      @RequestParam(defaultValue = "20") int size) {
 
-    CandidateApplyDto.Response response = candidateService.getApplyJobPostings(candidateKey);
+    CandidateApplyDto.Response response = candidateService.getApplyJobPostings(candidateKey, page, size);
 
     return ResponseEntity.ok(response);
   }

--- a/src/main/java/com/ctrls/auto_enter_view/controller/CandidateController.java
+++ b/src/main/java/com/ctrls/auto_enter_view/controller/CandidateController.java
@@ -1,5 +1,6 @@
 package com.ctrls.auto_enter_view.controller;
 
+import com.ctrls.auto_enter_view.dto.candidate.CandidateApplyDto;
 import com.ctrls.auto_enter_view.dto.candidate.ChangePasswordDto;
 import com.ctrls.auto_enter_view.dto.candidate.FindEmailDto;
 import com.ctrls.auto_enter_view.dto.candidate.FindEmailDto.Response;
@@ -65,4 +66,14 @@ public class CandidateController {
 
     return ResponseEntity.ok(response);
   }
+
+  // (지원자) 지원한 채용 공고 조회하기
+  @GetMapping("/candidates/{candidateKey}/applied-job-postings")
+  public ResponseEntity<CandidateApplyDto.Response> getApplyJobPosting(@PathVariable String candidateKey) {
+
+    CandidateApplyDto.Response response = candidateService.getApplyJobPostings(candidateKey);
+
+    return ResponseEntity.ok(response);
+  }
+
 }

--- a/src/main/java/com/ctrls/auto_enter_view/controller/JobPostingController.java
+++ b/src/main/java/com/ctrls/auto_enter_view/controller/JobPostingController.java
@@ -84,7 +84,7 @@ public class JobPostingController {
 
   // (지원자) 채용 공고 지원하기
   @PostMapping("/candidate/job-postings/{jobPostingKey}/apply")
-  public ResponseEntity<?> applyJobPosting(
+  public ResponseEntity<String> applyJobPosting(
       @PathVariable String jobPostingKey,
       @AuthenticationPrincipal UserDetails userDetails) {
 
@@ -95,4 +95,5 @@ public class JobPostingController {
 
     return ResponseEntity.ok(ResponseMessage.SUCCESS_JOB_POSTING_APPLY.getMessage());
   }
+
 }

--- a/src/main/java/com/ctrls/auto_enter_view/dto/candidate/CandidateApplyDto.java
+++ b/src/main/java/com/ctrls/auto_enter_view/dto/candidate/CandidateApplyDto.java
@@ -1,0 +1,50 @@
+package com.ctrls.auto_enter_view.dto.candidate;
+
+import com.ctrls.auto_enter_view.entity.JobPostingEntity;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class CandidateApplyDto {
+
+  @Getter
+  @AllArgsConstructor
+  @Builder
+  public static class Response {
+
+    private List<ApplyInfo> applyJobPostingsList;
+  }
+
+  @Getter
+  @AllArgsConstructor
+  @Builder
+  public static class ApplyInfo {
+
+    private String companyKey;
+    private String jobPostingKey;
+    private String title;
+    private String companyName;
+    private LocalDate startDate;
+    private LocalDate endDate;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime applyDate;
+
+    public static ApplyInfo from(JobPostingEntity entity, String companyName, LocalDateTime applyDate) {
+      return ApplyInfo.builder()
+          .companyKey(entity.getCompanyKey())
+          .jobPostingKey(entity.getJobPostingKey())
+          .title(entity.getTitle())
+          .companyName(companyName)
+          .startDate(entity.getStartDate())
+          .endDate(entity.getEndDate())
+          .applyDate(applyDate)
+          .build();
+    }
+  }
+
+}

--- a/src/main/java/com/ctrls/auto_enter_view/dto/candidate/CandidateApplyDto.java
+++ b/src/main/java/com/ctrls/auto_enter_view/dto/candidate/CandidateApplyDto.java
@@ -17,6 +17,8 @@ public class CandidateApplyDto {
   public static class Response {
 
     private List<ApplyInfo> applyJobPostingsList;
+    private int totalPages;
+    private long totalElements;
   }
 
   @Getter

--- a/src/main/java/com/ctrls/auto_enter_view/entity/BaseEntity.java
+++ b/src/main/java/com/ctrls/auto_enter_view/entity/BaseEntity.java
@@ -3,11 +3,13 @@ package com.ctrls.auto_enter_view.entity;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @EntityListeners(AuditingEntityListener.class)
+@Getter
 @MappedSuperclass
 public class BaseEntity {
 

--- a/src/main/java/com/ctrls/auto_enter_view/entity/CandidateListEntity.java
+++ b/src/main/java/com/ctrls/auto_enter_view/entity/CandidateListEntity.java
@@ -20,10 +20,10 @@ public class CandidateListEntity extends BaseEntity {
   @Id
   private String candidateListKey;
 
-  @Column(nullable = false, unique = true)
+  @Column(nullable = false)
   private Long jobPostingStepId;
 
-  @Column(nullable = false, unique = true)
+  @Column(nullable = false)
   private String jobPostingKey;
 
   @Column(nullable = false, unique = true)

--- a/src/main/java/com/ctrls/auto_enter_view/entity/CandidateListEntity.java
+++ b/src/main/java/com/ctrls/auto_enter_view/entity/CandidateListEntity.java
@@ -26,7 +26,7 @@ public class CandidateListEntity extends BaseEntity {
   @Column(nullable = false)
   private String jobPostingKey;
 
-  @Column(nullable = false, unique = true)
+  @Column(nullable = false)
   private String candidateKey;
 
   @Column(nullable = false)

--- a/src/main/java/com/ctrls/auto_enter_view/enums/ErrorCode.java
+++ b/src/main/java/com/ctrls/auto_enter_view/enums/ErrorCode.java
@@ -24,7 +24,8 @@ public enum ErrorCode {
   RESUME_NOT_FOUND(404, "지원자의 이력서를 찾을 수 없습니다"),
   TOKEN_BLACKLISTED(401, "토큰이 블랙리스트에 존재하여 사용할 수 없는 토큰입니다."),
   USER_NOT_FOUND(404, "사용자를 찾을 수 없습니다."),
-  ALREADY_APPLIED(404, "이미 지원한 채용 공고입니다.");
+  ALREADY_APPLIED(404, "이미 지원한 채용 공고입니다."),
+  APPLY_NOT_FOUND(404, "채용 공고에 지원한 정보를 찾을 수 없습니다.");
 
   private final int status;
   private final String message;

--- a/src/main/java/com/ctrls/auto_enter_view/enums/ResponseMessage.java
+++ b/src/main/java/com/ctrls/auto_enter_view/enums/ResponseMessage.java
@@ -16,7 +16,7 @@ public enum ResponseMessage {
   SUCCESS_UPDATE_COMPANY_INFO("회사 정보 수정이 완료되었습니다."),
   USABLE_EMAIL("사용 가능한 이메일입니다."),
   WITHDRAW("회원탈퇴 완료."),
-  SUCCESS_JOB_POSTING_APPLY("지원이 완료되었습니다.");
+  SUCCESS_JOB_POSTING_APPLY("지원이 완료되었습니다."),
   SUCCESS_EDIT_JOB_POSTING("채용 공고 수정 완료."),
   SUCCESS_DELETE_JOB_POSTING("채용 공고 삭제 완료.");
 

--- a/src/main/java/com/ctrls/auto_enter_view/repository/CandidateListRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/CandidateListRepository.java
@@ -2,14 +2,19 @@ package com.ctrls.auto_enter_view.repository;
 
 import com.ctrls.auto_enter_view.entity.CandidateListEntity;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface CandidateListRepository extends JpaRepository<CandidateListEntity, Long> {
+public interface CandidateListRepository extends JpaRepository<CandidateListEntity, String> {
 
   List<CandidateListEntity> findAllByJobPostingKeyAndJobPostingStepId(String jobPostingKey,
       Long jobPostingStepId);
 
   boolean existsByCandidateKeyAndJobPostingKey(String candidateKey, String jobPostingKey);
+
+  Optional<CandidateListEntity> findByCandidateKeyAndJobPostingKey(String candidateKey, String jobPostingKey);
+
+  List<CandidateListEntity> findAllByCandidateKey(String candidateKey);
 }

--- a/src/main/java/com/ctrls/auto_enter_view/repository/CandidateListRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/CandidateListRepository.java
@@ -2,7 +2,8 @@ package com.ctrls.auto_enter_view.repository;
 
 import com.ctrls.auto_enter_view.entity.CandidateListEntity;
 import java.util.List;
-import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,7 +15,6 @@ public interface CandidateListRepository extends JpaRepository<CandidateListEnti
 
   boolean existsByCandidateKeyAndJobPostingKey(String candidateKey, String jobPostingKey);
 
-  Optional<CandidateListEntity> findByCandidateKeyAndJobPostingKey(String candidateKey, String jobPostingKey);
+  Page<CandidateListEntity> findAllByCandidateKey(String candidateKey, Pageable pageable);
 
-  List<CandidateListEntity> findAllByCandidateKey(String candidateKey);
 }

--- a/src/main/java/com/ctrls/auto_enter_view/repository/JobPostingStepRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/JobPostingStepRepository.java
@@ -15,4 +15,6 @@ public interface JobPostingStepRepository extends JpaRepository<JobPostingStepEn
   void deleteByJobPostingKey(String jobPostingKey);
 
   JobPostingStepEntity findFirstByJobPostingKeyOrderByIdAsc(String jobPostingKey);
+
+  List<JobPostingStepEntity> findByJobPostingKey(String jobPostingKey);
 }

--- a/src/main/java/com/ctrls/auto_enter_view/service/CandidateService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/CandidateService.java
@@ -5,15 +5,25 @@ import static com.ctrls.auto_enter_view.enums.ErrorCode.EMAIL_NOT_FOUND;
 import static com.ctrls.auto_enter_view.enums.ErrorCode.PASSWORD_NOT_MATCH;
 import static com.ctrls.auto_enter_view.enums.ErrorCode.USER_NOT_FOUND;
 
+import com.ctrls.auto_enter_view.dto.candidate.CandidateApplyDto;
 import com.ctrls.auto_enter_view.dto.candidate.ChangePasswordDto.Request;
 import com.ctrls.auto_enter_view.dto.candidate.FindEmailDto;
 import com.ctrls.auto_enter_view.dto.candidate.FindEmailDto.Response;
 import com.ctrls.auto_enter_view.dto.candidate.SignUpDto;
 import com.ctrls.auto_enter_view.dto.candidate.WithdrawDto;
 import com.ctrls.auto_enter_view.entity.CandidateEntity;
+import com.ctrls.auto_enter_view.entity.CandidateListEntity;
+import com.ctrls.auto_enter_view.entity.CompanyEntity;
+import com.ctrls.auto_enter_view.entity.JobPostingEntity;
 import com.ctrls.auto_enter_view.enums.ErrorCode;
 import com.ctrls.auto_enter_view.exception.CustomException;
+import com.ctrls.auto_enter_view.repository.CandidateListRepository;
 import com.ctrls.auto_enter_view.repository.CandidateRepository;
+import com.ctrls.auto_enter_view.repository.CompanyRepository;
+import com.ctrls.auto_enter_view.repository.JobPostingRepository;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -27,7 +37,9 @@ import org.springframework.stereotype.Service;
 public class CandidateService {
 
   private final CandidateRepository candidateRepository;
-
+  private final CompanyRepository companyRepository;
+  private final CandidateListRepository candidateListRepository;
+  private final JobPostingRepository jobPostingRepository;
   private final PasswordEncoder passwordEncoder;
 
   // 회원 가입
@@ -110,10 +122,43 @@ public class CandidateService {
         .orElseThrow(() -> new CustomException(EMAIL_NOT_FOUND));
   }
 
-  // candidateKey -> 지원자 정보 조회
+  // candidateKey -> 지원자 정보 조회 : 이름
   public String getCandidateNameByKey(String candidateKey) {
     return candidateRepository.findByCandidateKey(candidateKey)
         .map(CandidateEntity::getName)
         .orElseThrow(() -> new CustomException(ErrorCode.CANDIDATE_NOT_FOUND));
+  }
+
+  // 지원자가 지원한 채용 공고 조회
+  public CandidateApplyDto.Response getApplyJobPostings(String candidateKey) {
+    List<CandidateListEntity> candidateListEntities = candidateListRepository.findAllByCandidateKey(candidateKey);
+
+    List<CandidateApplyDto.ApplyInfo> applyInfoList = new ArrayList<>();
+
+    for (CandidateListEntity candidateListEntity : candidateListEntities) {
+      JobPostingEntity jobPostingEntity = jobPostingRepository.findByJobPostingKey(candidateListEntity.getJobPostingKey())
+          .orElseThrow(() -> new CustomException(ErrorCode.JOB_POSTING_NOT_FOUND));
+
+      String companyName = getCompanyName(jobPostingEntity.getCompanyKey());
+      LocalDateTime applyDate = candidateListEntity.getCreatedAt();
+
+      CandidateApplyDto.ApplyInfo applyInfo = CandidateApplyDto.ApplyInfo.from(jobPostingEntity, companyName, applyDate);
+      applyInfoList.add(applyInfo);
+    }
+
+    log.info("{}개의 지원한 채용 공고 조회 완료", applyInfoList.size());
+    return CandidateApplyDto.Response.builder()
+        .applyJobPostingsList(applyInfoList)
+        .build();
+  }
+
+  // 회사 이름 가져오기
+  private String getCompanyName(String companyKey) {
+    CompanyEntity companyEntity = companyRepository.findByCompanyKey(companyKey)
+        .orElseThrow(() -> new CustomException(ErrorCode.COMPANY_NOT_FOUND));
+
+    String companyName = companyEntity.getCompanyName();
+    log.info("회사명 조회 완료 : {}", companyName);
+    return companyName;
   }
 }

--- a/src/test/java/com/ctrls/auto_enter_view/service/CandidateServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/CandidateServiceTest.java
@@ -1,22 +1,34 @@
 package com.ctrls.auto_enter_view.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import com.ctrls.auto_enter_view.dto.candidate.CandidateApplyDto;
 import com.ctrls.auto_enter_view.dto.candidate.ChangePasswordDto;
 import com.ctrls.auto_enter_view.dto.candidate.FindEmailDto.Request;
 import com.ctrls.auto_enter_view.dto.candidate.FindEmailDto.Response;
 import com.ctrls.auto_enter_view.dto.candidate.SignUpDto;
 import com.ctrls.auto_enter_view.dto.candidate.WithdrawDto;
 import com.ctrls.auto_enter_view.entity.CandidateEntity;
+import com.ctrls.auto_enter_view.entity.CandidateListEntity;
+import com.ctrls.auto_enter_view.entity.CompanyEntity;
+import com.ctrls.auto_enter_view.entity.JobPostingEntity;
 import com.ctrls.auto_enter_view.enums.ErrorCode;
 import com.ctrls.auto_enter_view.enums.UserRole;
 import com.ctrls.auto_enter_view.exception.CustomException;
+import com.ctrls.auto_enter_view.repository.CandidateListRepository;
 import com.ctrls.auto_enter_view.repository.CandidateRepository;
+import com.ctrls.auto_enter_view.repository.CompanyRepository;
+import com.ctrls.auto_enter_view.repository.JobPostingRepository;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -36,6 +48,15 @@ public class CandidateServiceTest {
 
   @Mock
   private CandidateRepository candidateRepository;
+
+  @Mock
+  private CandidateListRepository candidateListRepository;
+
+  @Mock
+  private JobPostingRepository jobPostingRepository;
+
+  @Mock
+  private CompanyRepository companyRepository;
 
   @Mock
   private PasswordEncoder passwordEncoder;
@@ -256,5 +277,127 @@ public class CandidateServiceTest {
     });
 
     assertEquals(ErrorCode.EMAIL_NOT_FOUND, exception.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("지원자가 지원한 채용 공고 조회 테스트 - 성공")
+  void getApplyJobPostingsSuccessTest() {
+    // given
+    String candidateKey = "candidateKey";
+    String jobPostingKey1 = "jobPostingKey1";
+    String jobPostingKey2 = "jobPostingKey2";
+    String companyKey1 = "companyKey1";
+    String companyKey2 = "companyKey2";
+    String companyName1 = "companyName1";
+    String companyName2 = "companyName2";
+
+    CandidateListEntity candidateListEntity1 = CandidateListEntity.builder()
+        .candidateKey(candidateKey)
+        .jobPostingKey(jobPostingKey1)
+        .build();
+
+    CandidateListEntity candidateListEntity2 = CandidateListEntity.builder()
+        .candidateKey(candidateKey)
+        .jobPostingKey(jobPostingKey2)
+        .build();
+
+    List<CandidateListEntity> candidateListEntities = Arrays.asList(candidateListEntity1, candidateListEntity2);
+
+    JobPostingEntity jobPostingEntity1 = JobPostingEntity.builder()
+        .jobPostingKey(jobPostingKey1)
+        .companyKey(companyKey1)
+        .build();
+
+    JobPostingEntity jobPostingEntity2 = JobPostingEntity.builder()
+        .jobPostingKey(jobPostingKey2)
+        .companyKey(companyKey2)
+        .build();
+
+    CompanyEntity companyEntity1 = CompanyEntity.builder()
+        .companyKey(companyKey1)
+        .companyName(companyName1)
+        .build();
+
+    CompanyEntity companyEntity2 = CompanyEntity.builder()
+        .companyKey(companyKey2)
+        .companyName(companyName2)
+        .build();
+
+    given(candidateListRepository.findAllByCandidateKey(candidateKey)).willReturn(candidateListEntities);
+    given(jobPostingRepository.findByJobPostingKey(jobPostingKey1)).willReturn(Optional.of(jobPostingEntity1));
+    given(jobPostingRepository.findByJobPostingKey(jobPostingKey2)).willReturn(Optional.of(jobPostingEntity2));
+    given(companyRepository.findByCompanyKey(companyKey1)).willReturn(Optional.of(companyEntity1));
+    given(companyRepository.findByCompanyKey(companyKey2)).willReturn(Optional.of(companyEntity2));
+
+    // when
+    CandidateApplyDto.Response response = candidateService.getApplyJobPostings(candidateKey);
+
+    // then
+    assertEquals(2, response.getApplyJobPostingsList().size());
+
+    CandidateApplyDto.ApplyInfo applyInfo1 = response.getApplyJobPostingsList().get(0);
+    assertEquals(jobPostingEntity1.getJobPostingKey(), applyInfo1.getJobPostingKey());
+    assertEquals(companyName1, applyInfo1.getCompanyName());
+
+    CandidateApplyDto.ApplyInfo applyInfo2 = response.getApplyJobPostingsList().get(1);
+    assertEquals(jobPostingEntity2.getJobPostingKey(), applyInfo2.getJobPostingKey());
+    assertEquals(companyName2, applyInfo2.getCompanyName());
+  }
+
+  @Test
+  @DisplayName("지원자가 지원한 채용 공고 조회 테스트 - 실패 : 채용 공고 찾을 수 없음")
+  void getApplyJobPostingsFailJobPostingNotFoundTest() {
+    // given
+    String candidateKey = "candidateKey";
+    String jobPostingKey = "jobPostingKey";
+
+    CandidateListEntity candidateListEntity = CandidateListEntity.builder()
+        .candidateKey(candidateKey)
+        .jobPostingKey(jobPostingKey)
+        .build();
+
+    List<CandidateListEntity> candidateListEntities = Collections.singletonList(candidateListEntity);
+
+    given(candidateListRepository.findAllByCandidateKey(candidateKey)).willReturn(candidateListEntities);
+    given(jobPostingRepository.findByJobPostingKey(jobPostingKey)).willReturn(Optional.empty());
+
+    // when
+    Throwable throwable = catchThrowable(() -> candidateService.getApplyJobPostings(candidateKey));
+
+    // then
+    assertThat(throwable).isInstanceOf(CustomException.class);
+    assertThat(((CustomException) throwable).getErrorCode()).isEqualTo(ErrorCode.JOB_POSTING_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("지원자가 지원한 채용 공고 조회 테스트 - 실패 : 회사 찾을 수 없음")
+  void getApplyJobPostingsFailCompanyNotFoundTest() {
+    // given
+    String candidateKey = "candidateKey";
+    String jobPostingKey = "jobPostingKey";
+    String companyKey = "companyKey";
+
+    CandidateListEntity candidateListEntity = CandidateListEntity.builder()
+        .candidateKey(candidateKey)
+        .jobPostingKey(jobPostingKey)
+        .build();
+
+    List<CandidateListEntity> candidateListEntities = Collections.singletonList(candidateListEntity);
+
+    JobPostingEntity jobPostingEntity = JobPostingEntity.builder()
+        .jobPostingKey(jobPostingKey)
+        .companyKey(companyKey)
+        .build();
+
+    given(candidateListRepository.findAllByCandidateKey(candidateKey)).willReturn(candidateListEntities);
+    given(jobPostingRepository.findByJobPostingKey(jobPostingKey)).willReturn(Optional.of(jobPostingEntity));
+    given(companyRepository.findByCompanyKey(companyKey)).willReturn(Optional.empty());
+
+    // when
+    Throwable throwable = catchThrowable(() -> candidateService.getApplyJobPostings(candidateKey));
+
+    // then
+    assertThat(throwable).isInstanceOf(CustomException.class);
+    assertThat(((CustomException) throwable).getErrorCode()).isEqualTo(ErrorCode.COMPANY_NOT_FOUND);
   }
 }


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 지원자가 본인이 지원한 채용공고 리스트를 볼 수 없음
- 지원자가 지원한 모든 채용공고를 가져오는데 페이징 처리가 안되어있음

**TO-BE**
- 지원자 본인이 지원한 모든 채용공고의 리스트를 조회할 수 있음
- 지원한 채용 공고에 대한 정보 제공 
: 회사명, 채용 공고 제목, 채용 공고 시작일&마감일, 채용 공고 지원 날짜
- 채용 공고 지원 날짜는 createdAt에서 가져온 날짜로 패턴 설정
- 페이징 처리 추가 : size 20, page 1을 디폴트 값으로 설정

### 테스트

- [x] 테스트 코드 작성
1. 지원자가 지원한 채용 공고 조회 성공 테스트
: 지원자가 지원한 채용 공고 정보를 정상적으로 조회할 수 있는지 테스트
- 지원자, 채용 공고, 회사 정보를 설정
-  getApplyJobPostings 메서드 호출
- 반환된 결과에서 지원한 채용 공고 정보와 회사명이 일치하는지 확인

2. 지원자가 지원한 채용 공고 조회 실패 테스트 - 채용 공고를 찾을 수 없음
: 지원자가 지원한 채용 공고가 존재하지 않는 경우 예외가 발생하는지 테스트
- 지원자와 존재하지 않는 채용 공고 정보를 설정
- getApplyJobPostings 메서드를 호출
- CustomException 발생 ->  JOB_POSTING_NOT_FOUND 일치하는지 확인

3. 지원자가 지원한 채용 공고 조회 실패 테스트 - 회사를 찾을 수 없음
: 지원자가 지원한 채용 공고는 존재 + 회사 정보가 존재하지 않는 경우 예외가 발생하는지 테스트
- 지원자, 채용 공고, 존재하지 않는 회사 정보를 설정
-  getApplyJobPostings 메서드를 호출
- CustomException 발생하고 -> COMPANY_NOT_FOUND 일치하는지 확인

- [x] API 테스트 