### PR TITLE
생성된 토큰을 헤더로 전달해주기

### DIFF
--- a/src/main/java/com/ctrls/auto_enter_view/dto/common/SignInDto.java
+++ b/src/main/java/com/ctrls/auto_enter_view/dto/common/SignInDto.java
@@ -35,28 +35,25 @@ public class SignInDto {
     private String key;
     private String name;
     private String email;
-    private String token;
     private UserRole role;
   }
 
-  public static Response fromCompany(CompanyEntity company, String token) {
+  public static Response fromCompany(CompanyEntity company) {
 
     return Response.builder()
         .key(company.getCompanyKey())
         .name(company.getCompanyName())
         .email(company.getEmail())
-        .token(token)
         .role(company.getRole())
         .build();
   }
 
-  public static Response fromCandidate(CandidateEntity candidate, String token) {
+  public static Response fromCandidate(CandidateEntity candidate) {
 
     return Response.builder()
         .key(candidate.getCandidateKey())
         .name(candidate.getName())
         .email(candidate.getEmail())
-        .token(token)
         .role(candidate.getRole())
         .build();
   }

--- a/src/main/java/com/ctrls/auto_enter_view/enums/ErrorCode.java
+++ b/src/main/java/com/ctrls/auto_enter_view/enums/ErrorCode.java
@@ -20,7 +20,7 @@ public enum ErrorCode {
   JOB_POSTING_STEP_NOT_FOUND(404, "채용 공고의 해당 단계를 찾을 수 없습니다"),
   NOT_FOUND(404, "페이지를 찾을 수 없습니다."),
   NO_AUTHORITY(401, "권한이 없습니다."),
-  PASSWORD_NOT_MATCH(400, "비밀번호가 일치하지 않습니다"),
+  PASSWORD_NOT_MATCH(400, "비밀번호가 일치하지 않습니다."),
   RESUME_NOT_FOUND(404, "지원자의 이력서를 찾을 수 없습니다"),
   TOKEN_BLACKLISTED(401, "토큰이 블랙리스트에 존재하여 사용할 수 없는 토큰입니다."),
   USER_NOT_FOUND(404, "사용자를 찾을 수 없습니다."),

--- a/src/main/java/com/ctrls/auto_enter_view/security/SecurityConfig.java
+++ b/src/main/java/com/ctrls/auto_enter_view/security/SecurityConfig.java
@@ -40,7 +40,7 @@ public class SecurityConfig {
         // JWT 인증을 사용하는 경우 - csrf 보호 비활성화
         .csrf(AbstractHttpConfigurer::disable)
 
-        // cors 설정 비활성화
+        // cors 설정 활성화
         .cors(cors -> cors.configurationSource(corsConfigurationSource()))
 
         // httpBasic 비활성화

--- a/src/main/java/com/ctrls/auto_enter_view/service/CommonUserService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/CommonUserService.java
@@ -14,7 +14,6 @@ import com.ctrls.auto_enter_view.enums.ErrorCode;
 import com.ctrls.auto_enter_view.exception.CustomException;
 import com.ctrls.auto_enter_view.repository.CandidateRepository;
 import com.ctrls.auto_enter_view.repository.CompanyRepository;
-import com.ctrls.auto_enter_view.security.JwtTokenProvider;
 import com.ctrls.auto_enter_view.util.RandomGenerator;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;

--- a/src/main/java/com/ctrls/auto_enter_view/service/CommonUserService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/CommonUserService.java
@@ -32,11 +32,9 @@ public class CommonUserService {
 
   private final CompanyRepository companyRepository;
   private final CandidateRepository candidateRepository;
+  private final BlacklistTokenService blacklistTokenService;
   private final MailComponent mailComponent;
   private final PasswordEncoder passwordEncoder;
-
-  private final JwtTokenProvider jwtTokenProvider;
-  private final BlacklistTokenService blacklistTokenService;
   private final RedisTemplate<String, String> redisTemplate;
 
   // 이메일을 통해 이메일의 사용 여부를 확인 - 회사
@@ -180,10 +178,11 @@ public class CommonUserService {
 
     // 회사 엔티티가 존재하는 경우
     if (companyOptional.isPresent()) {
+
       CompanyEntity company = companyOptional.get();
+
       if (passwordEncoder.matches(password, company.getPassword())) {
-        String token = jwtTokenProvider.generateToken(company.getEmail(), company.getRole());
-        return SignInDto.fromCompany(company, token);
+        return SignInDto.fromCompany(company);
       } else {
         throw new CustomException(ErrorCode.PASSWORD_NOT_MATCH);
       }
@@ -191,10 +190,11 @@ public class CommonUserService {
 
     // 후보자 엔티티가 존재하는 경우
     if (candidateOptional.isPresent()) {
+
       CandidateEntity candidate = candidateOptional.get();
+
       if (passwordEncoder.matches(password, candidate.getPassword())) {
-        String token = jwtTokenProvider.generateToken(candidate.getEmail(), candidate.getRole());
-        return SignInDto.fromCandidate(candidate, token);
+        return SignInDto.fromCandidate(candidate);
       } else {
         throw new CustomException(ErrorCode.PASSWORD_NOT_MATCH);
       }

--- a/src/test/java/com/ctrls/auto_enter_view/service/BlacklistTokenServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/BlacklistTokenServiceTest.java
@@ -10,12 +10,14 @@ import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
+@ExtendWith(MockitoExtension.class)
 class BlacklistTokenServiceTest {
 
   @Mock
@@ -29,7 +31,6 @@ class BlacklistTokenServiceTest {
 
   @BeforeEach
   void setUp() {
-    MockitoAnnotations.openMocks(this);
     when(redisTemplate.opsForValue()).thenReturn(valueOperations);
   }
 

--- a/src/test/java/com/ctrls/auto_enter_view/service/CommonUserServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/CommonUserServiceTest.java
@@ -251,7 +251,6 @@ class CommonUserServiceTest {
     assertEquals(email, response.getEmail());
     assertEquals(company.getCompanyKey(), response.getKey());
     assertEquals(companyName, response.getName());
-    assertEquals(generatedToken, response.getToken());
     assertEquals(UserRole.ROLE_COMPANY, response.getRole());
   }
 
@@ -283,7 +282,6 @@ class CommonUserServiceTest {
     assertEquals(email, response.getEmail());
     assertEquals(candidate.getCandidateKey(), response.getKey());
     assertEquals(name, response.getName());
-    assertEquals(generatedToken, response.getToken());
     assertEquals(UserRole.ROLE_CANDIDATE, response.getRole());
   }
 
@@ -327,7 +325,7 @@ class CommonUserServiceTest {
         () -> commonUserService.loginUser(email, password));
 
     // then
-    assertEquals("가입된 정보가 없습니다.", exception.getMessage());
+    assertEquals("사용자를 찾을 수 없습니다.", exception.getMessage());
   }
 
   @Test

--- a/src/test/java/com/ctrls/auto_enter_view/service/JobPostingServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/JobPostingServiceTest.java
@@ -294,7 +294,6 @@ class JobPostingServiceTest {
     verify(jobPostingStepRepository, times(1)).findFirstByJobPostingKeyOrderByIdAsc(jobPostingKey);
     verify(candidateListRepository, times(1)).existsByCandidateKeyAndJobPostingKey(candidateKey, jobPostingKey);
   }
-}
 
   @DisplayName("채용 공고 등록 성공 테스트")
   void testCreateJobPosting() {

--- a/src/test/java/com/ctrls/auto_enter_view/service/JobPostingServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/JobPostingServiceTest.java
@@ -27,13 +27,13 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
@@ -44,6 +44,7 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 
+@ExtendWith(MockitoExtension.class)
 class JobPostingServiceTest {
 
   @Mock
@@ -70,10 +71,10 @@ class JobPostingServiceTest {
   @InjectMocks
   private JobPostingService jobPostingService;
 
-  @BeforeEach
-  void setUp() {
-    MockitoAnnotations.openMocks(this);
-  }
+//  @BeforeEach
+//  void setUp() {
+//    MockitoAnnotations.openMocks(this);
+//  }
 
   @Test
   @DisplayName("회사 키로 채용 공고 목록 조회 - 성공")
@@ -434,9 +435,6 @@ class JobPostingServiceTest {
         .endDate(LocalDate.of(2024, 7, 20))
         .jobPostingContent("content")
         .build();
-
-    when(jobPostingRepository.findByJobPostingKey(jobPostingKey)).thenReturn(
-        Optional.of(jobPostingEntity));
 
     //when
     jobPostingService.deleteJobPosting(jobPostingKey);

--- a/src/test/java/com/ctrls/auto_enter_view/service/JobPostingServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/JobPostingServiceTest.java
@@ -311,8 +311,8 @@ class JobPostingServiceTest {
         .employmentType("employmentType")
         .salary(3000L)
         .workTime("workTime")
-        .startDate(LocalDate.of(2024, 07, 15))
-        .endDate(LocalDate.of(2024, 07, 20))
+        .startDate(LocalDate.of(2024, 7, 15))
+        .endDate(LocalDate.of(2024, 7, 20))
         .jobPostingContent("content")
         .build();
 
@@ -391,8 +391,8 @@ class JobPostingServiceTest {
         .employmentType("employmentType")
         .salary(3000L)
         .workTime("workTime")
-        .startDate(LocalDate.of(2024, 07, 15))
-        .endDate(LocalDate.of(2024, 07, 20))
+        .startDate(LocalDate.of(2024, 7, 15))
+        .endDate(LocalDate.of(2024, 7, 20))
         .jobPostingContent("content")
         .build();
 

--- a/src/test/java/com/ctrls/auto_enter_view/service/JobPostingServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/JobPostingServiceTest.java
@@ -403,7 +403,7 @@ class JobPostingServiceTest {
     jobPostingService.editJobPosting(jobPostingKey, request);
 
     //then
-    verify(jobPostingRepository, times(1));
+    verify(jobPostingRepository, times(1)).findByJobPostingKey(jobPostingKey);
 
     //제목, 고용타입만 바뀌는것 확인
     assertEquals(request.getTitle(), jobPostingEntity.getTitle());

--- a/src/test/java/com/ctrls/auto_enter_view/service/JobPostingServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/JobPostingServiceTest.java
@@ -327,8 +327,8 @@ class JobPostingServiceTest {
         .employmentType("employmentType")
         .salary(3000L)
         .workTime("workTime")
-        .startDate(LocalDate.of(2024, 07, 15))
-        .endDate(LocalDate.of(2024, 07, 20))
+        .startDate(LocalDate.of(2024, 7, 15))
+        .endDate(LocalDate.of(2024, 7, 20))
         .jobPostingContent("content")
         .build();
 
@@ -375,8 +375,8 @@ class JobPostingServiceTest {
         .employmentType("edit employmentType")
         .salary(3000L)
         .workTime("workTime")
-        .startDate(LocalDate.of(2024, 07, 15))
-        .endDate(LocalDate.of(2024, 07, 20))
+        .startDate(LocalDate.of(2024, 7, 15))
+        .endDate(LocalDate.of(2024, 7, 20))
         .jobPostingContent("content")
         .build();
 
@@ -430,8 +430,8 @@ class JobPostingServiceTest {
         .employmentType("employmentType")
         .salary(3000L)
         .workTime("workTime")
-        .startDate(LocalDate.of(2024, 07, 15))
-        .endDate(LocalDate.of(2024, 07, 20))
+        .startDate(LocalDate.of(2024, 7, 15))
+        .endDate(LocalDate.of(2024, 7, 20))
         .jobPostingContent("content")
         .build();
 


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 토큰 생성 기능이 서비스에 존재
- DTO response로 toekn 반환

**TO-BE**
- 토큰 생성 기능을 컨트롤러로 이동
- 생성된 토큰을 헤더로 전달
- Response에서 token 삭제

### 테스트
- 로그인 테스트에서 token 생성 부분만 수정
- [ ] API 테스트 