### PR TITLE
Refactor

### DIFF
--- a/src/main/java/com/ctrls/auto_enter_view/entity/CandidateEntity.java
+++ b/src/main/java/com/ctrls/auto_enter_view/entity/CandidateEntity.java
@@ -40,7 +40,4 @@ public class CandidateEntity extends BaseEntity {
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
   private UserRole role;
-
-  @Column(nullable = false)
-  private boolean isOpen;
 }

--- a/src/main/java/com/ctrls/auto_enter_view/entity/InterviewScheduleEntity.java
+++ b/src/main/java/com/ctrls/auto_enter_view/entity/InterviewScheduleEntity.java
@@ -24,10 +24,9 @@ public class InterviewScheduleEntity extends BaseEntity {
   @Column(nullable = false, unique = true)
   private Long jobPostingStepId;
 
-  @Column(nullable = false, unique = true)
+  @Column(nullable = false)
   private String jobPostingKey;
 
-  @Column(nullable = false)
   private LocalDate firstInterviewDate;
 
   @Column(nullable = false)

--- a/src/main/java/com/ctrls/auto_enter_view/entity/InterviewScheduleParticipantsEntity.java
+++ b/src/main/java/com/ctrls/auto_enter_view/entity/InterviewScheduleParticipantsEntity.java
@@ -24,16 +24,16 @@ public class InterviewScheduleParticipantsEntity extends BaseEntity {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  @Column(nullable = false, unique = true)
+  @Column(nullable = false)
   private String interviewScheduleKey;
 
-  @Column(nullable = false, unique = true)
+  @Column(nullable = false)
   private String candidateKey;
 
-  @Column(nullable = false, unique = true)
+  @Column(nullable = false)
   private String jobPostingKey;
 
-  @Column(nullable = false, unique = true)
+  @Column(nullable = false)
   private Long jobPostingStepId;
 
   private LocalDateTime interviewStartDatetime;

--- a/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
@@ -187,7 +187,8 @@ public class JobPostingStepService {
 
   // 채용 공고 key -> 채용 단계 조회
   public List<String> getStepByJobPostingKey(String jobPostingKey) {
-    List<JobPostingStepEntity> entities = jobPostingStepRepository.findByJobPostingKey(jobPostingKey);
+    List<JobPostingStepEntity> entities = jobPostingStepRepository.findByJobPostingKey(
+        jobPostingKey);
     List<String> step = new ArrayList<>();
 
     for (JobPostingStepEntity entity : entities) {

--- a/src/test/java/com/ctrls/auto_enter_view/service/JobPostingServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/JobPostingServiceTest.java
@@ -427,24 +427,6 @@ class JobPostingServiceTest {
     //given
     String jobPostingKey = "jobPostingKey";
 
-    String companyKey = "companyKey";
-
-    JobPostingEntity jobPostingEntity = JobPostingEntity.builder()
-        .jobPostingKey(jobPostingKey)
-        .companyKey(companyKey)
-        .title("title")
-        .jobCategory("jobCategory")
-        .career(3)
-        .workLocation("workLocation")
-        .education("education")
-        .employmentType("employmentType")
-        .salary(3000L)
-        .workTime("workTime")
-        .startDate(LocalDate.of(2024, 7, 15))
-        .endDate(LocalDate.of(2024, 7, 20))
-        .jobPostingContent("content")
-        .build();
-
     //when
     jobPostingService.deleteJobPosting(jobPostingKey);
 

--- a/src/test/java/com/ctrls/auto_enter_view/service/JobPostingStepServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/JobPostingStepServiceTest.java
@@ -27,17 +27,18 @@ import com.ctrls.auto_enter_view.repository.ResumeTechStackRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
 
+@ExtendWith(MockitoExtension.class)
 class JobPostingStepServiceTest {
 
   @Mock
@@ -61,16 +62,9 @@ class JobPostingStepServiceTest {
   @InjectMocks
   private JobPostingStepService jobPostingStepService;
 
-  @BeforeEach
-  void setUp() {
-
-    MockitoAnnotations.openMocks(this);
-  }
-
   @Test
   @DisplayName("채용 공고 단계 전체 조회 - 성공")
   void testGetJobPostingSteps_Success() {
-
     String jobPostingKey = "jobPostingKey";
     User user = new User("email", "password", new ArrayList<>());
     CompanyEntity companyEntity = CompanyEntity.builder()
@@ -105,7 +99,6 @@ class JobPostingStepServiceTest {
   @Test
   @DisplayName("채용 공고 단계 전체 조회 - 실패 : JOB_POSTING_NOT_FOUND 예외 발생")
   void testGetJobPostingSteps_JobPostingNotFound() {
-
     String jobPostingKey = "jobPostingKey";
     User user = new User("email", "password", new ArrayList<>());
 
@@ -127,7 +120,6 @@ class JobPostingStepServiceTest {
   @Test
   @DisplayName("채용 공고 단계 전체 조회 - 실패 : USER_NOT_FOUND 예외 발생")
   void testGetJobPostingSteps_UserNotFound() {
-
     String jobPostingKey = "jobPostingKey";
     User user = new User("email", "password", new ArrayList<>());
     JobPostingEntity jobPostingEntity = JobPostingEntity.builder()
@@ -155,7 +147,6 @@ class JobPostingStepServiceTest {
   @Test
   @DisplayName("해당 채용 단계의 지원자 리스트 조회 - 성공")
   void testGetCandidatesListByStepId_Success() {
-
     String jobPostingKey = "jobPostingKey";
     Long stepId = 1L;
     User user = new User("email", "password", new ArrayList<>());
@@ -216,7 +207,6 @@ class JobPostingStepServiceTest {
   @Test
   @DisplayName("해당 채용 단계의 지원자 리스트 조회 - 실패 : JOB_POSTING_NOT_FOUND 예외 발생")
   void testGetCandidatesListByStepId_JobPostingNotFound() {
-
     String jobPostingKey = "jobPostingKey";
     Long stepId = 1L;
     User user = new User("email", "password", new ArrayList<>());
@@ -239,7 +229,6 @@ class JobPostingStepServiceTest {
   @Test
   @DisplayName("해당 채용 단계의 지원자 리스트 조회 - 실패 : JOB_POSTING_STEP_NOT_FOUND 예외 발생")
   void testGetCandidatesListByStepId_StepNotFound() {
-
     String jobPostingKey = "jobPostingKey";
     Long stepId = 1L;
     User user = new User("email", "password", new ArrayList<>());

--- a/src/test/java/com/ctrls/auto_enter_view/test.http
+++ b/src/test/java/com/ctrls/auto_enter_view/test.http
@@ -5,10 +5,10 @@ Content-Type: application/json
 
 {
   "name": "임규리",
-  "email": "kgulr0517@naver.com",
+  "email": "kgulr0000@naver.com",
   "verificationCode": "aa",
   "password": "!JEi2ofj3",
-  "phoneNumber": "010-1111-1111"
+  "phoneNumber": "010-0000-1111"
 }
 
 ###
@@ -16,6 +16,10 @@ POST http://localhost:8080/common/signin
 Content-Type: application/json
 
 {
-  "email": "kgulr0517@naver.com",
-  "password": "Sw6!uWPAKV4b"
+  "email": "kgulr0000@naver.com",
+  "password": "!JEi2ofj3"
 }
+
+### 지원하기
+POST http://localhost:8080/candidate/job-postings/76f2d0c0f4c1424e92976035dedb9ce8/apply
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJrZ3VscjAwMDBAbmF2ZXIuY29tIiwicm9sZSI6IlJPTEVfQ0FORElEQVRFIiwiaWF0IjoxNzIwNTI3MTAwLCJleHAiOjE3MjA1MzA3MDB9.puaYDykl97nfOivOWaBimCou6OGbgUNTpWH_xRJXM6Q

--- a/src/test/java/com/ctrls/auto_enter_view/testJobPosting.http
+++ b/src/test/java/com/ctrls/auto_enter_view/testJobPosting.http
@@ -1,6 +1,6 @@
 ### create job posting test
-POST http://localhost:8080/companies/74811b4ad1264b03b0047206868efe11/job-postings
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjb21wYW55QG5hdmVyLmNvbSIsInJvbGUiOiJST0xFX0NPTVBBTlkiLCJpYXQiOjE3MjA1MjIwMTEsImV4cCI6MTcyMDUyNTYxMX0.G48xYsdhjpj4xl0MHx-w3vUK127vOPXiCE0kj7ajZyA
+POST http://localhost:8080/companies/0351b69102cc4c6bbe30e81cd5d6ac1b/job-postings
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjb21wYW55QG5hdmVyLmNvbSIsInJvbGUiOiJST0xFX0NPTVBBTlkiLCJpYXQiOjE3MjA1MjcwMDAsImV4cCI6MTcyMDUzMDYwMH0.-dOxwXUxPk59gQj3sEPQEW4PIrERuiDLxEx-o53qm-M
 Content-Type: application/json
 
 {
@@ -27,25 +27,19 @@ Content-Type: application/json
 
 
 ### get job postings test
-GET http://localhost:8080/companies/5165804fb170420a82785a2ddfa8478a/posted-job-postings
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjb21wYW55QG5hdmVyLmNvbSIsInJvbGUiOiJST0xFX0NPTVBBTlkiLCJpYXQiOjE3MjA0MjgxMDksImV4cCI6MTcyMDQzMTcwOX0.O421TLSEjx_tY8o28Xvr02mFzndbDvLCc5kivRJbr7c
+GET http://localhost:8080/companies/0351b69102cc4c6bbe30e81cd5d6ac1b/posted-job-postings
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjb21wYW55QG5hdmVyLmNvbSIsInJvbGUiOiJST0xFX0NPTVBBTlkiLCJpYXQiOjE3MjA1MjcwMDAsImV4cCI6MTcyMDUzMDYwMH0.-dOxwXUxPk59gQj3sEPQEW4PIrERuiDLxEx-o53qm-M
 Content-Type: application/json
 
 ### get job posting steps test
-GET http://localhost:8080/job-postings/3318da39258a499a8c067385ce15ab1a/steps
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjb21wYW55QG5hdmVyLmNvbSIsInJvbGUiOiJST0xFX0NPTVBBTlkiLCJpYXQiOjE3MjA0MjgxMDksImV4cCI6MTcyMDQzMTcwOX0.O421TLSEjx_tY8o28Xvr02mFzndbDvLCc5kivRJbr7c
+GET http://localhost:8080/job-postings/76f2d0c0f4c1424e92976035dedb9ce8/steps
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjb21wYW55QG5hdmVyLmNvbSIsInJvbGUiOiJST0xFX0NPTVBBTlkiLCJpYXQiOjE3MjA1MjcwMDAsImV4cCI6MTcyMDUzMDYwMH0.-dOxwXUxPk59gQj3sEPQEW4PIrERuiDLxEx-o53qm-M
 Content-Type: application/json
 
 ### 채용 공고에 지원한 지원자 목록을 단계별로 보여주는 api라, 지원하기 기능이 구현된 이후에 다시 테스트해봐야 할 것 같습니다.
 ### get job posting steps test 1
-GET http://localhost:8080/job-postings/3318da39258a499a8c067385ce15ab1a/steps/5/candidates-list
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjb21wYW55QG5hdmVyLmNvbSIsInJvbGUiOiJST0xFX0NPTVBBTlkiLCJpYXQiOjE3MjA0MjgxMDksImV4cCI6MTcyMDQzMTcwOX0.O421TLSEjx_tY8o28Xvr02mFzndbDvLCc5kivRJbr7c
-Content-Type: application/json
-
-### 채용 공고에 지원한 지원자 목록을 단계별로 보여주는 api라, 지원하기 기능이 구현된 이후에 다시 테스트해봐야 할 것 같습니다.
-### get job posting steps test 2
-GET http://localhost:8080/job-postings/3318da39258a499a8c067385ce15ab1a/steps/6/candidates-list
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjb21wYW55QG5hdmVyLmNvbSIsInJvbGUiOiJST0xFX0NPTVBBTlkiLCJpYXQiOjE3MjA0MjgxMDksImV4cCI6MTcyMDQzMTcwOX0.O421TLSEjx_tY8o28Xvr02mFzndbDvLCc5kivRJbr7c
+GET http://localhost:8080/job-postings/76f2d0c0f4c1424e92976035dedb9ce8/steps/5/candidates-list
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJjb21wYW55QG5hdmVyLmNvbSIsInJvbGUiOiJST0xFX0NPTVBBTlkiLCJpYXQiOjE3MjA1MjcwMDAsImV4cCI6MTcyMDUzMDYwMH0.-dOxwXUxPk59gQj3sEPQEW4PIrERuiDLxEx-o53qm-M
 Content-Type: application/json
 
 ### edit job posting test


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- CandidateEntity에 isOpen 컬럼이 존재함 - 이력서 공개 여부를 나타냄
- InterviewScheduleEntity의 jobPostingKey가 unique 설정이 되어 있음
- InterviewScheduleEntity의 firstInterviewDate가 null을 허용하지 않음
- 테스트 코드에서 @BeforeEach로 setUp() 함수에서 Mock을 설정함
 - InterviewScheduleParticipantsEntity의 interviewScheduleKey, candidateKey, jobPostingKey, jobPostingStepId가 unique하도록 설정이 되어 있음

**TO-BE**
- CandidateEntity의 isOpen 컬럼 삭제 
  - 이력서 공개 여부가 기능 상 더 이상 필요하지 않음
- InterviewScheduleEntity의 jobPostingKey가 unique 설정 삭제 
  - 면접 일정에는 해당 채용 공고에 지원한 여러 명의 지원자가 저장되어야 하는데, jobPostingKey가 unique로 설정되어 있으면 한 면접 일정에는 한 명의 지원자만 저장될 수 있음
- InterviewScheduleEntity의 firstInterviewDate가 null을 허용하도록 수정함
  - 과제 단계일 경우, 마감일만 존재하고 시작일이 존재하지 않을 수 있으므로 nullable하게 설정함
- 테스트 코드에서 @BeforeEach와 setUp() 함수를 삭제하고 대신 @ExtendWith(MockitoExtension.class)를 추가함
- InterviewScheduleParticipantsEntity의 interviewScheduleKey, candidateKey, jobPostingKey, jobPostingStepId의 unique 삭제
  - 면접 일정 참가자 테이블에 Key값들이 겹치면 마찬가지로 한 명의 지원자만 저장될 수 있기에 삭제함


### 테스트
<!-- 본 변경 사항이 테스트가 되었는지 기술해주세요 --> 
- 테스트 코드
  - 채용 공고 삭제 성공 테스트에서 사용되지 않는 변수들 삭제
- API 테스트 
  - 지원자 : 지원하기 기능 테스트