### PR TITLE
Feature/add new column to job posting

### DIFF
--- a/src/main/java/com/ctrls/auto_enter_view/dto/jobPosting/JobPostingDto.java
+++ b/src/main/java/com/ctrls/auto_enter_view/dto/jobPosting/JobPostingDto.java
@@ -58,6 +58,9 @@ public class JobPostingDto {
 
     private String jobPostingContent;
 
+    @NotNull(message = "서류 통과 인원은 필수 입력 항목입니다.")
+    private Integer passingNumber;
+
     public static JobPostingEntity toEntity(String companyKey, Request request) {
 
       return JobPostingEntity.builder()
@@ -74,6 +77,7 @@ public class JobPostingDto {
           .endDate(request.getEndDate())
           .workTime(request.getWorkTime())
           .jobPostingContent(request.getJobPostingContent())
+          .passingNumber(request.getPassingNumber())
           .build();
     }
 

--- a/src/main/java/com/ctrls/auto_enter_view/entity/JobPostingEntity.java
+++ b/src/main/java/com/ctrls/auto_enter_view/entity/JobPostingEntity.java
@@ -70,5 +70,6 @@ public class JobPostingEntity extends BaseEntity {
     this.startDate = request.getStartDate();
     this.endDate = request.getEndDate();
     this.jobPostingContent = request.getJobPostingContent();
+    this.passingNumber = request.getPassingNumber();
   }
 }


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 채용 공고 생성 시 서류 통과 인원(passingNumber) 정보 누락
- 채용 공고 수정 시 passingNumber 정보를 업데이트하지 않음

**TO-BE**
- JobPostingDto.Request에 passingNumber 필드 추가
- 채용 공고 생성 시 입력받은 passingNumber 정보를 JobPostingEntity에 저장
- 채용 공고 수정 시 passingNumber 정보도 업데이트되도록 수정

### 테스트
- [x] API 테스트 