### PR TITLE
사용자 탈퇴 시 관련 데이터 전부 삭제하기

### DIFF
--- a/src/main/java/com/ctrls/auto_enter_view/controller/JobPostingController.java
+++ b/src/main/java/com/ctrls/auto_enter_view/controller/JobPostingController.java
@@ -3,7 +3,9 @@ package com.ctrls.auto_enter_view.controller;
 import com.ctrls.auto_enter_view.dto.jobPosting.JobPostingDto;
 import com.ctrls.auto_enter_view.dto.jobPosting.JobPostingInfoDto;
 import com.ctrls.auto_enter_view.entity.JobPostingEntity;
+import com.ctrls.auto_enter_view.enums.ErrorCode;
 import com.ctrls.auto_enter_view.enums.ResponseMessage;
+import com.ctrls.auto_enter_view.exception.CustomException;
 import com.ctrls.auto_enter_view.service.CandidateService;
 import com.ctrls.auto_enter_view.service.JobPostingImageService;
 import com.ctrls.auto_enter_view.service.JobPostingService;
@@ -111,6 +113,10 @@ public class JobPostingController {
 
     String candidateEmail = userDetails.getUsername();
     String candidateKey = candidateService.findCandidateKeyByEmail(candidateEmail);
+
+    if (!candidateService.hasResume(candidateKey)) {
+      throw new CustomException(ErrorCode.RESUME_NOT_FOUND);
+    }
 
     jobPostingService.applyJobPosting(jobPostingKey, candidateKey);
 

--- a/src/main/java/com/ctrls/auto_enter_view/entity/ApplicantEntity.java
+++ b/src/main/java/com/ctrls/auto_enter_view/entity/ApplicantEntity.java
@@ -28,4 +28,9 @@ public class ApplicantEntity extends BaseEntity {
 
   @Column(nullable = false)
   private String candidateKey;
+
+  @Column(nullable = false)
+  @Builder.Default
+  private int score = 0;
+
 }

--- a/src/main/java/com/ctrls/auto_enter_view/entity/InterviewScheduleEntity.java
+++ b/src/main/java/com/ctrls/auto_enter_view/entity/InterviewScheduleEntity.java
@@ -1,6 +1,5 @@
 package com.ctrls.auto_enter_view.entity;
 
-import com.ctrls.auto_enter_view.dto.interviewschedule.InterviewScheduleParticipantsDto.Request;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;

--- a/src/main/java/com/ctrls/auto_enter_view/repository/ApplicantRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/ApplicantRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 public interface ApplicantRepository extends JpaRepository<ApplicantEntity, Long> {
 
   List<ApplicantEntity> findAllByJobPostingKey(String jobPostingKey);
+
+  boolean existsByCandidateKeyAndJobPostingKey(String candidateKey, String jobPostingKey);
 }

--- a/src/main/java/com/ctrls/auto_enter_view/repository/ApplicantRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/ApplicantRepository.java
@@ -3,6 +3,8 @@ package com.ctrls.auto_enter_view.repository;
 import com.ctrls.auto_enter_view.entity.ApplicantEntity;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,4 +13,8 @@ public interface ApplicantRepository extends JpaRepository<ApplicantEntity, Long
   List<ApplicantEntity> findAllByJobPostingKey(String jobPostingKey);
 
   boolean existsByCandidateKeyAndJobPostingKey(String candidateKey, String jobPostingKey);
+
+  @Modifying
+  @Query("DELETE FROM ApplicantEntity r WHERE r.candidateKey = :candidateKey")
+  void deleteByCandidateKey(String candidateKey);
 }

--- a/src/main/java/com/ctrls/auto_enter_view/repository/CandidateListRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/CandidateListRepository.java
@@ -16,8 +16,6 @@ public interface CandidateListRepository extends JpaRepository<CandidateListEnti
 
   boolean existsByJobPostingKeyAndJobPostingStepId(String jobPostingKey, Long jobPostingStepId);
 
-  boolean existsByCandidateKeyAndJobPostingKey(String candidateKey, String jobPostingKey);
-
   Page<CandidateListEntity> findAllByCandidateKey(String candidateKey, Pageable pageable);
 
   @Query("SELECT c.candidateKey FROM CandidateListEntity c WHERE c.jobPostingKey = :jobPostingKey AND c.jobPostingStepId = :stepId")

--- a/src/main/java/com/ctrls/auto_enter_view/repository/CandidateListRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/CandidateListRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -24,4 +25,8 @@ public interface CandidateListRepository extends JpaRepository<CandidateListEnti
   
   @Query("SELECT c.candidateName FROM CandidateListEntity c WHERE c.candidateKey = :candidateKey")
   String findCandidateNameByCandidateKey(String candidateKey);
+
+  @Modifying
+  @Query("DELETE FROM CandidateListEntity r WHERE r.candidateKey = :candidateKey")
+  void deleteByCandidateKey(String candidateKey);
 }

--- a/src/main/java/com/ctrls/auto_enter_view/repository/InterviewScheduleParticipantsRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/InterviewScheduleParticipantsRepository.java
@@ -3,6 +3,8 @@ package com.ctrls.auto_enter_view.repository;
 import com.ctrls.auto_enter_view.entity.InterviewScheduleParticipantsEntity;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -17,4 +19,8 @@ public interface InterviewScheduleParticipantsRepository extends
 
   InterviewScheduleParticipantsEntity findByInterviewScheduleKeyAndCandidateKey(
       String interviewScheduleKey, String candidateKey);
+
+  @Modifying
+  @Query("DELETE FROM InterviewScheduleParticipantsEntity r WHERE r.candidateKey = :candidateKey")
+  void deleteByCandidateKey(String candidateKey);
 }

--- a/src/main/java/com/ctrls/auto_enter_view/repository/InterviewScheduleParticipantsRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/InterviewScheduleParticipantsRepository.java
@@ -1,6 +1,5 @@
 package com.ctrls.auto_enter_view.repository;
 
-import com.ctrls.auto_enter_view.entity.InterviewScheduleEntity;
 import com.ctrls.auto_enter_view.entity.InterviewScheduleParticipantsEntity;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/ctrls/auto_enter_view/service/CandidateService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/CandidateService.java
@@ -19,6 +19,7 @@ import com.ctrls.auto_enter_view.repository.CandidateListRepository;
 import com.ctrls.auto_enter_view.repository.CandidateRepository;
 import com.ctrls.auto_enter_view.repository.CompanyRepository;
 import com.ctrls.auto_enter_view.repository.JobPostingRepository;
+import com.ctrls.auto_enter_view.repository.ResumeRepository;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +42,7 @@ public class CandidateService {
   private final CompanyRepository companyRepository;
   private final CandidateListRepository candidateListRepository;
   private final JobPostingRepository jobPostingRepository;
+  private final ResumeRepository resumeRepository;
   private final PasswordEncoder passwordEncoder;
 
   // 회원 가입
@@ -96,6 +98,11 @@ public class CandidateService {
     return candidateRepository.findByEmail(candidateEmail)
         .map(CandidateEntity::getCandidateKey)
         .orElseThrow(() -> new CustomException(EMAIL_NOT_FOUND));
+  }
+
+  // 이력서 존재 여부 확인하기
+  public boolean hasResume(String candidateKey) {
+    return resumeRepository.existsByCandidateKey(candidateKey);
   }
 
   // candidateKey -> 지원자 정보 조회 : 이름

--- a/src/main/java/com/ctrls/auto_enter_view/service/InterviewScheduleParticipantsService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/InterviewScheduleParticipantsService.java
@@ -4,7 +4,6 @@ import com.ctrls.auto_enter_view.dto.candidateList.CandidateListDto;
 import com.ctrls.auto_enter_view.dto.interviewschedule.InterviewScheduleDto.Request;
 import com.ctrls.auto_enter_view.dto.interviewschedule.InterviewScheduleParticipantsDto;
 import com.ctrls.auto_enter_view.dto.interviewschedule.InterviewScheduleParticipantsDto.Response;
-import com.ctrls.auto_enter_view.entity.CandidateListEntity;
 import com.ctrls.auto_enter_view.entity.InterviewScheduleEntity;
 import com.ctrls.auto_enter_view.entity.InterviewScheduleParticipantsEntity;
 import com.ctrls.auto_enter_view.enums.ErrorCode;
@@ -14,7 +13,6 @@ import com.ctrls.auto_enter_view.repository.InterviewScheduleParticipantsReposit
 import com.ctrls.auto_enter_view.repository.InterviewScheduleRepository;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/ctrls/auto_enter_view/service/JobPostingService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/JobPostingService.java
@@ -27,7 +27,6 @@ import com.ctrls.auto_enter_view.repository.CandidateRepository;
 import com.ctrls.auto_enter_view.repository.CompanyRepository;
 import com.ctrls.auto_enter_view.repository.JobPostingRepository;
 import com.ctrls.auto_enter_view.repository.JobPostingStepRepository;
-import com.ctrls.auto_enter_view.util.KeyGenerator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -218,38 +217,22 @@ public class JobPostingService {
       throw new CustomException(JOB_POSTING_NOT_FOUND);
     }
 
-    // 이름 가져오기
-    String candidateName = candidateService.getCandidateNameByKey(candidateKey);
-
-    // 해당 채용 공고의 첫 번째 단계 가져오기
-    JobPostingStepEntity firstStep = getJobPostingStepEntity(jobPostingKey);
-
     // 채용 지원 중복 체크
-    boolean isApplied = candidateListRepository.existsByCandidateKeyAndJobPostingKey(candidateKey,
+    boolean isApplied = applicantRepository.existsByCandidateKeyAndJobPostingKey(candidateKey,
         jobPostingKey);
     if (isApplied) {
       throw new CustomException(ErrorCode.ALREADY_APPLIED);
     }
 
-    CandidateListEntity candidateList = CandidateListEntity.builder()
-        .candidateListKey(KeyGenerator.generateKey())
-        .jobPostingStepId(firstStep.getId())
-        .jobPostingKey(jobPostingKey)
-        .candidateKey(candidateKey)
-        .candidateName(candidateName)
-        .build();
-
-    candidateListRepository.save(candidateList);
-    log.info("지원 완료 - jobPostingKey: {}, candidateKey: {}", jobPostingKey, candidateKey);
-
     // 응시자 추가하기
     ApplicantEntity applicantEntity = ApplicantEntity.builder()
         .jobPostingKey(jobPostingKey)
         .candidateKey(candidateKey)
+        .score(0)
         .build();
 
     applicantRepository.save(applicantEntity);
-    log.info("Applicant 추가 완료");
+    log.info("지원 완료 - jobPostingKey: {}, candidateKey: {}", jobPostingKey, candidateKey);
   }
 
   private JobPostingStepEntity getJobPostingStepEntity(String jobPostingKey) {


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 지원자가 이력서 없이도 채용공고 지원 가능
- 사용자가 탈퇴 시 남아있는 데이터가 존재

**TO-BE**
- 지원자 탈퇴 시 관련된 모든 데이터 삭제 구현
1. [이력서] 지원자가 작성한 이력서 삭제 (resumeRepository)
2. [응시자] 지원자 삭제 (applicantRepository)
3. [채용 단계에 지원한 지원자] 지원자 삭제(candidateListRepository)
4. [면접 일정 참여자]  지원자 삭제 (interviewScheduleParticipantsRepository)

- 회사 탈퇴 시 회사 정보 삭제

- 이력서가 없으면 채용공고 지원 불가능
: 지원할 때 이력서 유무 확인하는 로직 추가

### 테스트
- [x] API 테스트 