### PR TITLE
scoring + filtering 스케줄링 기능 현

### DIFF
--- a/src/main/java/com/ctrls/auto_enter_view/component/FilteringJob.java
+++ b/src/main/java/com/ctrls/auto_enter_view/component/FilteringJob.java
@@ -1,0 +1,25 @@
+package com.ctrls.auto_enter_view.component;
+
+import com.ctrls.auto_enter_view.service.FilteringService;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FilteringJob implements Job {
+
+  private FilteringService filteringService;
+
+  @Override
+  public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+    String jobPostingKey = jobExecutionContext.getJobDetail().getJobDataMap()
+        .getString("jobPostingKey");
+
+    try {
+      filteringService.filterCandidates(jobPostingKey);
+    } catch (Exception e) {
+      throw new JobExecutionException("Failed to filter candidates", e);
+    }
+  }
+}

--- a/src/main/java/com/ctrls/auto_enter_view/component/FilteringJob.java
+++ b/src/main/java/com/ctrls/auto_enter_view/component/FilteringJob.java
@@ -1,15 +1,17 @@
 package com.ctrls.auto_enter_view.component;
 
 import com.ctrls.auto_enter_view.service.FilteringService;
+import lombok.RequiredArgsConstructor;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class FilteringJob implements Job {
 
-  private FilteringService filteringService;
+  private final FilteringService filteringService;
 
   @Override
   public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {

--- a/src/main/java/com/ctrls/auto_enter_view/component/ScoringJob.java
+++ b/src/main/java/com/ctrls/auto_enter_view/component/ScoringJob.java
@@ -1,0 +1,31 @@
+package com.ctrls.auto_enter_view.component;
+
+import com.ctrls.auto_enter_view.entity.ApplicantEntity;
+import com.ctrls.auto_enter_view.repository.ApplicantRepository;
+import com.ctrls.auto_enter_view.service.FilteringService;
+import java.util.List;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ScoringJob implements Job {
+
+  private FilteringService filteringService;
+  private ApplicantRepository applicantRepository;
+
+  @Override
+  public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+    String jobPostingKey = jobExecutionContext.getJobDetail().getJobDataMap()
+        .getString("jobPostingKey");
+
+    // 해당 jobPosting의 applicantEntity 리스트를 받아오기
+    List<ApplicantEntity> applicants = applicantRepository.findAllByJobPostingKey(jobPostingKey);
+
+    for (ApplicantEntity applicantEntity : applicants) {
+      // 지원자별로 이력서 점수 매기기
+      filteringService.calculateResumeScore(applicantEntity.getCandidateKey(), jobPostingKey);
+    }
+  }
+}

--- a/src/main/java/com/ctrls/auto_enter_view/component/ScoringJob.java
+++ b/src/main/java/com/ctrls/auto_enter_view/component/ScoringJob.java
@@ -4,16 +4,18 @@ import com.ctrls.auto_enter_view.entity.ApplicantEntity;
 import com.ctrls.auto_enter_view.repository.ApplicantRepository;
 import com.ctrls.auto_enter_view.service.FilteringService;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.quartz.Job;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class ScoringJob implements Job {
 
-  private FilteringService filteringService;
-  private ApplicantRepository applicantRepository;
+  private final FilteringService filteringService;
+  private final ApplicantRepository applicantRepository;
 
   @Override
   public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {

--- a/src/main/java/com/ctrls/auto_enter_view/service/FilteringService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/FilteringService.java
@@ -44,6 +44,7 @@ import lombok.RequiredArgsConstructor;
 import org.quartz.JobBuilder;
 import org.quartz.JobDataMap;
 import org.quartz.JobDetail;
+import org.quartz.JobKey;
 import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.quartz.SimpleScheduleBuilder;
@@ -214,6 +215,12 @@ public class FilteringService {
       // 마감일 다음 날 자정으로 설정
       LocalDateTime filteringDateTime = LocalDateTime.of(endDate.plusDays(1), LocalTime.MIDNIGHT);
 
+      // 기존 작업이 있는지 확인하고 제거
+      JobKey jobKeyA = JobKey.jobKey("resumeScoringJob", "group1");
+      if (scheduler.checkExists(jobKeyA)) {
+        scheduler.deleteJob(jobKeyA);
+      }
+
       // 스코어링 스케줄링
       JobDataMap jobDataMapA = new JobDataMap();
       jobDataMapA.put("jobPostingKey", jobPostingKey);
@@ -233,6 +240,11 @@ public class FilteringService {
       scheduler.scheduleJob(jobDetailA, triggerA);
 
       // 필터링 스케줄링
+      JobKey jobKeyB = JobKey.jobKey("filteringJob", "group1");
+      if (scheduler.checkExists(jobKeyB)) {
+        scheduler.deleteJob(jobKeyB);
+      }
+
       JobDataMap jobDataMapB = new JobDataMap();
       jobDataMapB.put("jobPostingKey", jobPostingKey);
 

--- a/src/main/java/com/ctrls/auto_enter_view/service/FilteringService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/FilteringService.java
@@ -35,6 +35,7 @@ import org.quartz.SchedulerException;
 import org.quartz.SimpleScheduleBuilder;
 import org.quartz.Trigger;
 import org.quartz.TriggerBuilder;
+import org.quartz.TriggerKey;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -210,6 +211,17 @@ public class FilteringService {
       scheduler.scheduleJob(jobDetail, trigger);
     } catch (SchedulerException e) {
       throw new RuntimeException("Failed to schedule resume scoring job", e);
+    }
+  }
+
+  // 스케줄링 취소
+  public void unscheduleResumeScoringJob(String jobPostingKey) {
+    try {
+      TriggerKey triggerKey = TriggerKey.triggerKey("resumeScoringTrigger-" + jobPostingKey,
+          "resumeScoringGroup");
+      scheduler.unscheduleJob(triggerKey);
+    } catch (SchedulerException e) {
+      throw new RuntimeException("Failed to unschedule resume scoring job", e);
     }
   }
 }

--- a/src/main/java/com/ctrls/auto_enter_view/service/JobPostingService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/JobPostingService.java
@@ -58,6 +58,7 @@ public class JobPostingService {
   private final AppliedJobPostingRepository appliedJobPostingRepository;
   private final JobPostingStepService jobPostingStepService;
   private final JobPostingImageService jobPostingImageService;
+  private final FilteringService filteringService;
   private final MailComponent mailComponent;
 
   /**
@@ -73,6 +74,10 @@ public class JobPostingService {
         COMPANY_NOT_FOUND));
 
     JobPostingEntity entity = Request.toEntity(companyKey, request);
+
+    // 스케줄링 코드
+    filteringService.scheduleResumeScoringJob(entity.getJobPostingKey(), entity.getEndDate());
+
     return jobPostingRepository.save(entity);
   }
 

--- a/src/main/java/com/ctrls/auto_enter_view/service/JobPostingService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/JobPostingService.java
@@ -127,8 +127,14 @@ public class JobPostingService {
       throw new CustomException(NO_AUTHORITY);
     }
 
+    // 이전에 스케줄된 작업 취소
+    filteringService.unscheduleResumeScoringJob(jobPostingKey);
+
     // 채용 공고 수정
     jobPostingEntity.updateEntity(request);
+
+    // 새로운 스케줄 설정
+    filteringService.scheduleResumeScoringJob(jobPostingKey, request.getEndDate());
 
     // 지원자 목록을 순회하며 이메일 보내기
     notifyCandidates(candidateListEntityList, jobPostingEntity);


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 채용 공고를 기반으로 지원자들의 이력서를 점수화하는 기능 부재
- 지원자들의 이력서 점수를 기반으로 서류 필터링 인원만큼 서류 단계로 이동시키는 기능 부재


**TO-BE**
1. 채용 공고 생성 시 자동으로 스케줄링을 생성함
2. 채용 공고 수정 시 자동으로 이미 존재하는 스케줄링 작업을 취소시키고 새로운 스케줄링을 생성함

- 채용 공고를 기반으로 지원자들의 이력서를 점수화하는 기능 추가
  - 채용 공고의 endDate(마감일) 하루 후 자정에 자동으로 점수화하는 기능 추가 : Quartz 사용
  - e.g. endDate가 "2024-07-20"이면 "2024-07-21 00:00:00"에 점수화 스케줄링이 실행됨

- 지원자들의 이력서 점수를 기반으로 서류 필터링 인원만큼 서류 단계로 이동시키는 기능 추가 : Quartz 사용
  - 점수화 스케줄링이 실행되고 1분 후 서류 필터링 인원만큼 서류 단계로 이동시켜주는 필터링 스케줄링이 실행됨
  - e.g. endDate가 "2024-07-20"이면 "2024-07-21 00:01:00"에 필터링 스케줄링이 실행됨
  - 점수가 높은 순서대로 정렬하고, 만약 지원자들끼리 점수가 같다면 지원한 시간(createdAt)이 빠른 순서대로 정렬함


### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] API 테스트 