### PR TITLE
지원자 탈퇴 기능에서 개인정보만 삭제하도록 수정

### DIFF
--- a/src/main/java/com/ctrls/auto_enter_view/repository/ApplicantRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/ApplicantRepository.java
@@ -4,8 +4,6 @@ import com.ctrls.auto_enter_view.entity.ApplicantEntity;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -14,10 +12,6 @@ public interface ApplicantRepository extends JpaRepository<ApplicantEntity, Long
   List<ApplicantEntity> findAllByJobPostingKey(String jobPostingKey);
 
   boolean existsByCandidateKeyAndJobPostingKey(String candidateKey, String jobPostingKey);
-
-  @Modifying
-  @Query("DELETE FROM ApplicantEntity r WHERE r.candidateKey = :candidateKey")
-  void deleteByCandidateKey(String candidateKey);
 
   Optional<ApplicantEntity> findByCandidateKeyAndJobPostingKey(String candidateKey, String jobPostingKey);
 }

--- a/src/main/java/com/ctrls/auto_enter_view/repository/CandidateListRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/CandidateListRepository.java
@@ -6,7 +6,6 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
@@ -26,10 +25,6 @@ public interface CandidateListRepository extends JpaRepository<CandidateListEnti
   
   @Query("SELECT c.candidateName FROM CandidateListEntity c WHERE c.candidateKey = :candidateKey")
   String findCandidateNameByCandidateKey(String candidateKey);
-
-  @Modifying
-  @Query("DELETE FROM CandidateListEntity r WHERE r.candidateKey = :candidateKey")
-  void deleteByCandidateKey(String candidateKey);
 
   Optional<CandidateListEntity> findByCandidateKeyAndJobPostingKey(String candidateKey, String jobPostingKey);
 }

--- a/src/main/java/com/ctrls/auto_enter_view/repository/InterviewScheduleParticipantsRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/InterviewScheduleParticipantsRepository.java
@@ -4,8 +4,6 @@ import com.ctrls.auto_enter_view.entity.InterviewScheduleParticipantsEntity;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -23,8 +21,5 @@ public interface InterviewScheduleParticipantsRepository extends
 
   Optional<InterviewScheduleParticipantsEntity> findByJobPostingStepIdAndCandidateKey(Long stepId,
       String candidateKey);
-  
-  @Modifying
-  @Query("DELETE FROM InterviewScheduleParticipantsEntity r WHERE r.candidateKey = :candidateKey")
-  void deleteByCandidateKey(String candidateKey);
+
 }

--- a/src/main/java/com/ctrls/auto_enter_view/service/CommonUserService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/CommonUserService.java
@@ -15,12 +15,9 @@ import com.ctrls.auto_enter_view.entity.CandidateEntity;
 import com.ctrls.auto_enter_view.entity.CompanyEntity;
 import com.ctrls.auto_enter_view.enums.UserRole;
 import com.ctrls.auto_enter_view.exception.CustomException;
-import com.ctrls.auto_enter_view.repository.ApplicantRepository;
-import com.ctrls.auto_enter_view.repository.CandidateListRepository;
 import com.ctrls.auto_enter_view.repository.CandidateRepository;
 import com.ctrls.auto_enter_view.repository.CompanyInfoRepository;
 import com.ctrls.auto_enter_view.repository.CompanyRepository;
-import com.ctrls.auto_enter_view.repository.InterviewScheduleParticipantsRepository;
 import com.ctrls.auto_enter_view.repository.ResumeRepository;
 import com.ctrls.auto_enter_view.util.RandomGenerator;
 import java.util.Collection;
@@ -47,9 +44,6 @@ public class CommonUserService {
   private final CompanyInfoRepository companyInfoRepository;
   private final CandidateRepository candidateRepository;
   private final ResumeRepository resumeRepository;
-  private final ApplicantRepository applicantRepository;
-  private final CandidateListRepository candidateListRepository;
-  private final InterviewScheduleParticipantsRepository interviewScheduleParticipantsRepository;
   private final MailComponent mailComponent;
   private final PasswordEncoder passwordEncoder;
   private final RedisTemplate<String, String> redisTemplate;
@@ -295,15 +289,6 @@ public class CommonUserService {
 
         // 지원자가 작성한 이력서 삭제
         resumeRepository.deleteByCandidateKey(candidateEntity.getCandidateKey());
-
-        // 지원자가 지원한 채용 공고 이력 삭제
-        applicantRepository.deleteByCandidateKey(candidateEntity.getCandidateKey());
-
-        // 채용 공고 단계가 있다면 이력 삭제
-        candidateListRepository.deleteByCandidateKey(candidateEntity.getCandidateKey());
-
-        // 지원자와 관련된 면접 일정 삭제
-        interviewScheduleParticipantsRepository.deleteByCandidateKey(candidateEntity.getCandidateKey());
 
         // 지원자 삭제
         candidateRepository.delete(candidateEntity);


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 지원자 탈퇴 시 채용 공고 관련 정보 전부 삭제

**TO-BE**
- 지원자 탈퇴 시 개인 정보만 삭제 되도록 수정

### 테스트

- [x] API 테스트 