### PR TITLE
Refactor/dto validation

### DIFF
--- a/src/main/java/com/ctrls/auto_enter_view/controller/JobPostingStepController.java
+++ b/src/main/java/com/ctrls/auto_enter_view/controller/JobPostingStepController.java
@@ -2,7 +2,6 @@ package com.ctrls.auto_enter_view.controller;
 
 import com.ctrls.auto_enter_view.dto.jobPosting.JobPostingEveryInfoDto;
 import com.ctrls.auto_enter_view.dto.jobPostingStep.EditJobPostingStepDto;
-import com.ctrls.auto_enter_view.dto.jobPostingStep.JobPostingStepsDto;
 import com.ctrls.auto_enter_view.enums.ResponseMessage;
 import com.ctrls.auto_enter_view.service.JobPostingStepService;
 import java.util.List;
@@ -25,18 +24,6 @@ public class JobPostingStepController {
   private final JobPostingStepService jobPostingStepService;
 
   /**
-   * 채용 공고 단계 전체 조회
-   *
-   * @param jobPostingKey
-   * @return
-   */
-  @GetMapping("/steps")
-  public ResponseEntity<JobPostingStepsDto> getJobPostingSteps(@PathVariable String jobPostingKey) {
-
-    return ResponseEntity.ok(jobPostingStepService.getJobPostingSteps(jobPostingKey));
-  }
-
-  /**
    * 전체 채용 단계의 지원자 리스트 조회 : 채용단계 ID - 지원자 key, 지원자 이름, 이력서 key, 기술 스택 리스트, 면접 일시
    *
    * @param jobPostingKey
@@ -57,7 +44,8 @@ public class JobPostingStepController {
       @PathVariable String jobPostingKey,
       @AuthenticationPrincipal UserDetails userDetails) {
 
-    jobPostingStepService.editStepId(request.getCurrentStepId(), request.getCandidateKey(), jobPostingKey, userDetails);
+    jobPostingStepService.editStepId(request.getCurrentStepId(), request.getCandidateKey(),
+        jobPostingKey, userDetails);
     return ResponseEntity.ok(ResponseMessage.SUCCESS_STEP_MOVEMENT.getMessage());
   }
 }

--- a/src/main/java/com/ctrls/auto_enter_view/dto/jobPosting/JobPostingEveryInfoDto.java
+++ b/src/main/java/com/ctrls/auto_enter_view/dto/jobPosting/JobPostingEveryInfoDto.java
@@ -15,5 +15,7 @@ public class JobPostingEveryInfoDto {
 
   private Long stepId;
 
+  private String stepName;
+
   private List<CandidateTechStackInterviewInfoDto> candidateTechStackInterviewInfoDtoList;
 }

--- a/src/main/java/com/ctrls/auto_enter_view/entity/AppliedJobPostingEntity.java
+++ b/src/main/java/com/ctrls/auto_enter_view/entity/AppliedJobPostingEntity.java
@@ -33,4 +33,8 @@ public class AppliedJobPostingEntity {
   private LocalDate startDate;
   private String stepName;
   private String title;
+
+  public void updateStepName(String newStepName) {
+    this.stepName = newStepName;
+  }
 }

--- a/src/main/java/com/ctrls/auto_enter_view/repository/AppliedJobPostingRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/AppliedJobPostingRepository.java
@@ -1,6 +1,7 @@
 package com.ctrls.auto_enter_view.repository;
 
 import com.ctrls.auto_enter_view.entity.AppliedJobPostingEntity;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,4 +11,6 @@ import org.springframework.stereotype.Repository;
 public interface AppliedJobPostingRepository extends JpaRepository<AppliedJobPostingEntity, Long> {
 
   Page<AppliedJobPostingEntity> findAllByCandidateKey(String candidateKey, Pageable pageable);
+
+  Optional<AppliedJobPostingEntity> findByCandidateKey(String candidateKey);
 }

--- a/src/main/java/com/ctrls/auto_enter_view/service/FilteringService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/FilteringService.java
@@ -23,6 +23,7 @@ import com.ctrls.auto_enter_view.repository.JobPostingStepRepository;
 import com.ctrls.auto_enter_view.util.KeyGenerator;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.ZoneId;
 import java.util.Comparator;
 import java.util.Date;

--- a/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
@@ -122,6 +122,7 @@ public class JobPostingStepService {
 
         jobPostingEveryInfoDtoList.add(JobPostingEveryInfoDto.builder()
             .stepId(jobPostingStepEntity.getId())
+            .stepName(jobPostingStepEntity.getStep())
             .candidateTechStackInterviewInfoDtoList(candidateTechStackInterviewInfoDtoList)
             .build()
         );
@@ -143,6 +144,7 @@ public class JobPostingStepService {
 
         jobPostingEveryInfoDtoList.add(JobPostingEveryInfoDto.builder()
             .stepId(jobPostingStepEntity.getId())
+            .stepName(jobPostingStepEntity.getStep())
             .candidateTechStackInterviewInfoDtoList(candidateTechStackInterviewInfoDtoList)
             .build()
         );
@@ -163,6 +165,7 @@ public class JobPostingStepService {
 
         jobPostingEveryInfoDtoList.add(JobPostingEveryInfoDto.builder()
             .stepId(jobPostingStepEntity.getId())
+            .stepName(jobPostingStepEntity.getStep())
             .candidateTechStackInterviewInfoDtoList(candidateTechStackInterviewInfoDtoList)
             .build()
         );

--- a/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
@@ -8,8 +8,6 @@ import com.ctrls.auto_enter_view.dto.candidateList.CandidateTechStackInterviewIn
 import com.ctrls.auto_enter_view.dto.jobPosting.JobPostingDto;
 import com.ctrls.auto_enter_view.dto.jobPosting.JobPostingDto.Request;
 import com.ctrls.auto_enter_view.dto.jobPosting.JobPostingEveryInfoDto;
-import com.ctrls.auto_enter_view.dto.jobPostingStep.JobPostingStepDto;
-import com.ctrls.auto_enter_view.dto.jobPostingStep.JobPostingStepsDto;
 import com.ctrls.auto_enter_view.entity.CandidateListEntity;
 import com.ctrls.auto_enter_view.entity.CompanyEntity;
 import com.ctrls.auto_enter_view.entity.InterviewScheduleEntity;
@@ -69,32 +67,6 @@ public class JobPostingStepService {
     log.info("Saved jobPostingSteps : {}", savedEntities.stream()
         .map(e -> "id: " + e.getId() + ", step: " + e.getStep())
         .collect(Collectors.toList()));
-  }
-
-  /**
-   * 채용 공고 단계 전체 조회
-   *
-   * @param jobPostingKey
-   * @return
-   */
-  public JobPostingStepsDto getJobPostingSteps(String jobPostingKey) {
-
-    JobPostingEntity jobPosting = findJobPostingEntityByJobPostingKey(jobPostingKey);
-
-    User principal = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-    CompanyEntity company = findCompanyByPrincipal(principal);
-
-    verifyCompanyOwnership(company, jobPosting);
-
-    List<JobPostingStepEntity> jobPostingSteps = jobPostingStepRepository.findAllByJobPostingKey(
-        jobPostingKey);
-    List<JobPostingStepDto> jobPostingStepDtoList = JobPostingStepDto.fromEntityList(
-        jobPostingSteps);
-
-    return JobPostingStepsDto.builder()
-        .jobPostingKey(jobPostingKey)
-        .jobPostingSteps(jobPostingStepDtoList)
-        .build();
   }
 
   /**

--- a/src/test/java/com/ctrls/auto_enter_view/service/JobPostingStepServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/JobPostingStepServiceTest.java
@@ -1,37 +1,15 @@
 package com.ctrls.auto_enter_view.service;
 
-import static com.ctrls.auto_enter_view.enums.ErrorCode.JOB_POSTING_NOT_FOUND;
-import static com.ctrls.auto_enter_view.enums.ErrorCode.USER_NOT_FOUND;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-
-import com.ctrls.auto_enter_view.dto.jobPostingStep.JobPostingStepsDto;
-import com.ctrls.auto_enter_view.entity.CompanyEntity;
-import com.ctrls.auto_enter_view.entity.JobPostingEntity;
-import com.ctrls.auto_enter_view.entity.JobPostingStepEntity;
-import com.ctrls.auto_enter_view.exception.CustomException;
 import com.ctrls.auto_enter_view.repository.CandidateListRepository;
 import com.ctrls.auto_enter_view.repository.CompanyRepository;
 import com.ctrls.auto_enter_view.repository.JobPostingRepository;
 import com.ctrls.auto_enter_view.repository.JobPostingStepRepository;
 import com.ctrls.auto_enter_view.repository.ResumeRepository;
 import com.ctrls.auto_enter_view.repository.ResumeTechStackRepository;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.User;
 
 @ExtendWith(MockitoExtension.class)
 class JobPostingStepServiceTest {
@@ -56,88 +34,6 @@ class JobPostingStepServiceTest {
 
   @InjectMocks
   private JobPostingStepService jobPostingStepService;
-
-  @Test
-  @DisplayName("채용 공고 단계 전체 조회 - 성공")
-  void testGetJobPostingSteps_Success() {
-    String jobPostingKey = "jobPostingKey";
-    User user = new User("email", "password", new ArrayList<>());
-    CompanyEntity companyEntity = CompanyEntity.builder()
-        .companyKey("companyKey")
-        .build();
-    JobPostingEntity jobPostingEntity = JobPostingEntity.builder()
-        .companyKey("companyKey")
-        .build();
-    JobPostingStepEntity stepEntity1 = new JobPostingStepEntity();
-    JobPostingStepEntity stepEntity2 = new JobPostingStepEntity();
-    List<JobPostingStepEntity> jobPostingSteps = List.of(stepEntity1, stepEntity2);
-
-    when(jobPostingRepository.findByJobPostingKey(jobPostingKey)).thenReturn(
-        Optional.of(jobPostingEntity));
-    when(companyRepository.findByEmail(user.getUsername())).thenReturn(Optional.of(companyEntity));
-    when(jobPostingStepRepository.findAllByJobPostingKey(jobPostingKey)).thenReturn(
-        jobPostingSteps);
-
-    SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
-    securityContext.setAuthentication(
-        new UsernamePasswordAuthenticationToken(user, user.getPassword(), user.getAuthorities()));
-    SecurityContextHolder.setContext(securityContext);
-
-    JobPostingStepsDto result = jobPostingStepService.getJobPostingSteps(jobPostingKey);
-
-    verify(jobPostingRepository, times(1)).findByJobPostingKey(jobPostingKey);
-    verify(companyRepository, times(1)).findByEmail(user.getUsername());
-    verify(jobPostingStepRepository, times(1)).findAllByJobPostingKey(jobPostingKey);
-    assertEquals(2, result.getJobPostingSteps().size());
-  }
-
-  @Test
-  @DisplayName("채용 공고 단계 전체 조회 - 실패 : JOB_POSTING_NOT_FOUND 예외 발생")
-  void testGetJobPostingSteps_JobPostingNotFound() {
-    String jobPostingKey = "jobPostingKey";
-    User user = new User("email", "password", new ArrayList<>());
-
-    when(jobPostingRepository.findByJobPostingKey(jobPostingKey)).thenReturn(Optional.empty());
-
-    SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
-    securityContext.setAuthentication(
-        new UsernamePasswordAuthenticationToken(user, user.getPassword(), user.getAuthorities()));
-    SecurityContextHolder.setContext(securityContext);
-
-    CustomException exception = assertThrows(CustomException.class, () -> {
-      jobPostingStepService.getJobPostingSteps(jobPostingKey);
-    });
-
-    verify(jobPostingRepository, times(1)).findByJobPostingKey(jobPostingKey);
-    assertEquals(JOB_POSTING_NOT_FOUND, exception.getErrorCode());
-  }
-
-  @Test
-  @DisplayName("채용 공고 단계 전체 조회 - 실패 : USER_NOT_FOUND 예외 발생")
-  void testGetJobPostingSteps_UserNotFound() {
-    String jobPostingKey = "jobPostingKey";
-    User user = new User("email", "password", new ArrayList<>());
-    JobPostingEntity jobPostingEntity = JobPostingEntity.builder()
-        .companyKey("companyKey")
-        .build();
-
-    when(jobPostingRepository.findByJobPostingKey(jobPostingKey)).thenReturn(
-        Optional.of(jobPostingEntity));
-    when(companyRepository.findByEmail(user.getUsername())).thenReturn(Optional.empty());
-
-    SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
-    securityContext.setAuthentication(
-        new UsernamePasswordAuthenticationToken(user, user.getPassword(), user.getAuthorities()));
-    SecurityContextHolder.setContext(securityContext);
-
-    CustomException exception = assertThrows(CustomException.class, () -> {
-      jobPostingStepService.getJobPostingSteps(jobPostingKey);
-    });
-
-    verify(jobPostingRepository, times(1)).findByJobPostingKey(jobPostingKey);
-    verify(companyRepository, times(1)).findByEmail(user.getUsername());
-    assertEquals(USER_NOT_FOUND, exception.getErrorCode());
-  }
 
 //  @Test
 //  @DisplayName("해당 채용 단계의 지원자 리스트 조회 - 성공")


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 지원자가 채용 공고 마감일 이후에 스케줄링을 통해 서류 단계로 넘어가도 AppliedJobPostingEntity의 stepName은 기본 값인 "지원 완료"라 업데이트 되지 않음
- JobPostingStepController : 채용 공고의 단계들을 조회해오는 api 존재 -> 사용 X
- JobPostingEveryInfo에 stepId만 존재하고, stepName이 없음

**TO-BE**
- AppliedJobPostingEntity의 stepName을 업데이트할 메소드 추가 : updateStepName()
- FilteringService - filterCandidates() : 지원자별로 AppliedJobPostingEntity를 찾아서 stepName을 해당 채용 공고의 첫번째 단계명으로 업데이트해주는 로직 추가
- JobPostingStepController : 채용 공고의 단계들을 조회해오는 api 삭제
  - 관련된 서비스 로직 삭제
  - 관련된 테스트 코드 삭제
- JobPostingEveryInfo에 stepName 추가

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] API 테스트 