### PR TITLE
리팩토링 및 ENUM 직렬기 추가

### DIFF
--- a/src/main/java/com/ctrls/auto_enter_view/component/EducationSerializer.java
+++ b/src/main/java/com/ctrls/auto_enter_view/component/EducationSerializer.java
@@ -1,0 +1,17 @@
+package com.ctrls.auto_enter_view.component;
+
+import com.ctrls.auto_enter_view.enums.Education;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+
+public class EducationSerializer extends JsonSerializer<Education> {
+
+  @Override
+  public void serialize(Education value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+
+    gen.writeString(value.getValue());
+  }
+}

--- a/src/main/java/com/ctrls/auto_enter_view/component/JobCategorySerializer.java
+++ b/src/main/java/com/ctrls/auto_enter_view/component/JobCategorySerializer.java
@@ -1,0 +1,17 @@
+package com.ctrls.auto_enter_view.component;
+
+import com.ctrls.auto_enter_view.enums.JobCategory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+
+public class JobCategorySerializer extends JsonSerializer<JobCategory> {
+
+  @Override
+  public void serialize(JobCategory value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+
+    gen.writeString(value.getValue());
+  }
+}

--- a/src/main/java/com/ctrls/auto_enter_view/component/TechStackDeserializer.java
+++ b/src/main/java/com/ctrls/auto_enter_view/component/TechStackDeserializer.java
@@ -6,9 +6,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import java.io.IOException;
-import org.springframework.stereotype.Component;
 
-@Component
 public class TechStackDeserializer extends JsonDeserializer<TechStack> {
 
   @Override

--- a/src/main/java/com/ctrls/auto_enter_view/component/TechStackSerializer.java
+++ b/src/main/java/com/ctrls/auto_enter_view/component/TechStackSerializer.java
@@ -1,0 +1,17 @@
+package com.ctrls.auto_enter_view.component;
+
+import com.ctrls.auto_enter_view.enums.TechStack;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import java.io.IOException;
+
+public class TechStackSerializer extends JsonSerializer<TechStack> {
+
+  @Override
+  public void serialize(TechStack value, JsonGenerator gen, SerializerProvider serializers)
+      throws IOException {
+
+    gen.writeString(value.getValue());
+  }
+}

--- a/src/main/java/com/ctrls/auto_enter_view/config/JsonConfig.java
+++ b/src/main/java/com/ctrls/auto_enter_view/config/JsonConfig.java
@@ -1,6 +1,11 @@
 package com.ctrls.auto_enter_view.config;
 
+import com.ctrls.auto_enter_view.component.EducationSerializer;
+import com.ctrls.auto_enter_view.component.JobCategorySerializer;
 import com.ctrls.auto_enter_view.component.TechStackDeserializer;
+import com.ctrls.auto_enter_view.component.TechStackSerializer;
+import com.ctrls.auto_enter_view.enums.Education;
+import com.ctrls.auto_enter_view.enums.JobCategory;
 import com.ctrls.auto_enter_view.enums.TechStack;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -22,6 +27,13 @@ public class JsonConfig {
 
     // TechStack
     simpleModule.addDeserializer(TechStack.class, new TechStackDeserializer());
+    simpleModule.addSerializer(TechStack.class, new TechStackSerializer());
+
+    // JobCategory
+    simpleModule.addSerializer(JobCategory.class, new JobCategorySerializer());
+
+    // Education
+    simpleModule.addSerializer(Education.class, new EducationSerializer());
 
     // LocalDate
     DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");

--- a/src/main/java/com/ctrls/auto_enter_view/config/JsonConfig.java
+++ b/src/main/java/com/ctrls/auto_enter_view/config/JsonConfig.java
@@ -11,8 +11,10 @@ import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -42,6 +44,10 @@ public class JsonConfig {
     // LocalDateTime
     DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
     simpleModule.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer(dateTimeFormatter));
+
+    // LocalTime
+    DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern("HH:mm");
+    simpleModule.addSerializer(LocalTime.class, new LocalTimeSerializer(timeFormatter));
 
     return simpleModule;
   }

--- a/src/main/java/com/ctrls/auto_enter_view/dto/candidateList/CandidateTechStackInterviewInfoDto.java
+++ b/src/main/java/com/ctrls/auto_enter_view/dto/candidateList/CandidateTechStackInterviewInfoDto.java
@@ -1,7 +1,6 @@
 package com.ctrls.auto_enter_view.dto.candidateList;
 
 import com.ctrls.auto_enter_view.enums.TechStack;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -23,6 +22,5 @@ public class CandidateTechStackInterviewInfoDto {
 
   private List<TechStack> techStack;
 
-  @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
   private LocalDateTime scheduleDateTime;
 }

--- a/src/main/java/com/ctrls/auto_enter_view/dto/candidateList/CandidateTechStackInterviewInfoDto.java
+++ b/src/main/java/com/ctrls/auto_enter_view/dto/candidateList/CandidateTechStackInterviewInfoDto.java
@@ -1,5 +1,6 @@
 package com.ctrls.auto_enter_view.dto.candidateList;
 
+import com.ctrls.auto_enter_view.enums.TechStack;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -20,7 +21,7 @@ public class CandidateTechStackInterviewInfoDto {
 
   private String resumeKey;
 
-  private List<String> techStack;
+  private List<TechStack> techStack;
 
   @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
   private LocalDateTime scheduleDateTime;

--- a/src/main/java/com/ctrls/auto_enter_view/dto/common/JobPostingDetailDto.java
+++ b/src/main/java/com/ctrls/auto_enter_view/dto/common/JobPostingDetailDto.java
@@ -1,10 +1,11 @@
 package com.ctrls.auto_enter_view.dto.common;
 
 import com.ctrls.auto_enter_view.entity.JobPostingEntity;
+import com.ctrls.auto_enter_view.enums.Education;
+import com.ctrls.auto_enter_view.enums.JobCategory;
 import com.ctrls.auto_enter_view.enums.TechStack;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,10 +20,10 @@ public class JobPostingDetailDto {
     private String jobPostingKey;
     private String companyKey;
     private String title;
-    private String jobCategory;
+    private JobCategory jobCategory;
     private Integer career;
     private String workLocation;
-    private String education;
+    private Education education;
     private String employmentType;
     private Long salary;
     private String workTime;
@@ -30,7 +31,7 @@ public class JobPostingDetailDto {
     private LocalDate endDate;
     private String jobPostingContent;
 
-    private List<String> techStack;
+    private List<TechStack> techStack;
     private List<String> step;
     private String image;
 
@@ -41,17 +42,17 @@ public class JobPostingDetailDto {
           .jobPostingKey(entity.getJobPostingKey())
           .companyKey(entity.getCompanyKey())
           .title(entity.getTitle())
-          .jobCategory(entity.getJobCategory().getValue())
+          .jobCategory(entity.getJobCategory())
           .career(entity.getCareer())
           .workLocation(entity.getWorkLocation())
-          .education(entity.getEducation().getValue())
+          .education(entity.getEducation())
           .employmentType(entity.getEmploymentType())
           .salary(entity.getSalary())
           .workTime(entity.getWorkTime())
           .startDate(entity.getStartDate())
           .endDate(entity.getEndDate())
           .jobPostingContent(entity.getJobPostingContent())
-          .techStack(techStack.stream().map(TechStack::getValue).collect(Collectors.toList()))
+          .techStack(techStack)
           .step(step)
           .image(imageUrl)
           .build();

--- a/src/main/java/com/ctrls/auto_enter_view/dto/common/MainJobPostingDto.java
+++ b/src/main/java/com/ctrls/auto_enter_view/dto/common/MainJobPostingDto.java
@@ -4,7 +4,6 @@ import com.ctrls.auto_enter_view.entity.JobPostingEntity;
 import com.ctrls.auto_enter_view.enums.TechStack;
 import java.time.LocalDate;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,7 +28,7 @@ public class MainJobPostingDto {
     private String jobPostingKey;
     private String companyName;
     private String title;
-    private List<String> techStack;
+    private List<TechStack> techStack;
     private LocalDate endDate;
 
     public static JobPostingMainInfo from(JobPostingEntity entity, String companyName,
@@ -39,7 +38,7 @@ public class MainJobPostingDto {
           .jobPostingKey(entity.getJobPostingKey())
           .companyName(companyName)
           .title(entity.getTitle())
-          .techStack(techStack.stream().map(TechStack::getValue).collect(Collectors.toList()))
+          .techStack(techStack)
           .endDate(entity.getEndDate())
           .build();
     }

--- a/src/main/java/com/ctrls/auto_enter_view/dto/interviewschedule/InterviewScheduleDto.java
+++ b/src/main/java/com/ctrls/auto_enter_view/dto/interviewschedule/InterviewScheduleDto.java
@@ -13,7 +13,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
 
 public class InterviewScheduleDto {
 
@@ -27,7 +26,6 @@ public class InterviewScheduleDto {
     private LocalDate startDate;
 
     @NotNull(message = "시작시간은 필수 입력값 입니다.")
-    @DateTimeFormat(pattern = "HH:mm")
     private LocalTime startTime;
 
     @Min(value = 1, message = "구간은 1분 이상이어야 합니다.")

--- a/src/main/java/com/ctrls/auto_enter_view/dto/interviewschedule/InterviewScheduleParticipantsDto.java
+++ b/src/main/java/com/ctrls/auto_enter_view/dto/interviewschedule/InterviewScheduleParticipantsDto.java
@@ -1,7 +1,6 @@
 package com.ctrls.auto_enter_view.dto.interviewschedule;
 
 import com.ctrls.auto_enter_view.entity.InterviewScheduleParticipantsEntity;
-import com.fasterxml.jackson.annotation.JsonFormat;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -16,10 +15,8 @@ public class InterviewScheduleParticipantsDto {
   @NoArgsConstructor
   public static class Request {
 
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime interviewStartDatetime;
 
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm")
     private LocalDateTime interviewEndDatetime;
   }
 

--- a/src/main/java/com/ctrls/auto_enter_view/dto/resume/CareerDto.java
+++ b/src/main/java/com/ctrls/auto_enter_view/dto/resume/CareerDto.java
@@ -48,7 +48,7 @@ public class CareerDto {
   public static class Response {
 
     private String companyName;
-    private String jobCategory;
+    private JobCategory jobCategory;
     private LocalDate startDate;
     private LocalDate endDate;
     private int calculatedCareer;

--- a/src/main/java/com/ctrls/auto_enter_view/dto/resume/ResumeDto.java
+++ b/src/main/java/com/ctrls/auto_enter_view/dto/resume/ResumeDto.java
@@ -4,6 +4,7 @@ import com.ctrls.auto_enter_view.entity.ResumeEntity;
 import com.ctrls.auto_enter_view.enums.Education;
 import com.ctrls.auto_enter_view.enums.JobCategory;
 import com.ctrls.auto_enter_view.enums.TechStack;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
@@ -50,9 +51,16 @@ public class ResumeDto {
     private String schoolName;
 
     private List<TechStack> techStack;
+
+    @Valid
     private List<ExperienceDto> experience;
+
+    @Valid
     private List<CareerDto.Request> career;
+
+    @Valid
     private List<CertificateDto> certificates;
+
     private String portfolio;
 
     public ResumeEntity toEntity(String resumeKey, String candidateKey) {

--- a/src/main/java/com/ctrls/auto_enter_view/dto/resume/ResumeReadDto.java
+++ b/src/main/java/com/ctrls/auto_enter_view/dto/resume/ResumeReadDto.java
@@ -5,6 +5,8 @@ import com.ctrls.auto_enter_view.entity.ResumeCertificateEntity;
 import com.ctrls.auto_enter_view.entity.ResumeEntity;
 import com.ctrls.auto_enter_view.entity.ResumeExperienceEntity;
 import com.ctrls.auto_enter_view.entity.ResumeTechStackEntity;
+import com.ctrls.auto_enter_view.enums.Education;
+import com.ctrls.auto_enter_view.enums.JobCategory;
 import com.ctrls.auto_enter_view.enums.TechStack;
 import java.time.LocalDate;
 import java.util.List;
@@ -21,20 +23,20 @@ public class ResumeReadDto {
     private String resumeKey;
     private String candidateKey;
     private String title;
-    private String jobWant;
+    private JobCategory jobWant;
     private String name;
     private String gender;
     private LocalDate birthDate;
     private String email;
     private String phoneNumber;
     private String address;
-    private String education;
+    private Education education;
     private String schoolName;
     private String portfolio;
     private List<CareerDto.Response> career;
     private List<CertificateDto> certificates;
     private List<ExperienceDto> experience;
-    private List<String> techStack;
+    private List<TechStack> techStack;
     private String resumeImageUrl;
 
     public static ResponseBuilder builder() {
@@ -47,20 +49,20 @@ public class ResumeReadDto {
       private String resumeKey;
       private String candidateKey;
       private String title;
-      private String jobWant;
+      private JobCategory jobWant;
       private String name;
       private String gender;
       private LocalDate birthDate;
       private String email;
       private String phoneNumber;
       private String address;
-      private String education;
+      private Education education;
       private String schoolName;
       private String portfolio;
       private List<CareerDto.Response> career;
       private List<CertificateDto> certificates;
       private List<ExperienceDto> experience;
-      private List<String> techStack;
+      private List<TechStack> techStack;
       private String resumeImageUrl;
 
       ResponseBuilder() {
@@ -72,14 +74,14 @@ public class ResumeReadDto {
         resumeKey = resumeEntity.getResumeKey();
         candidateKey = resumeEntity.getCandidateKey();
         title = resumeEntity.getTitle();
-        jobWant = resumeEntity.getJobWant().getValue();
+        jobWant = resumeEntity.getJobWant();
         name = resumeEntity.getName();
         gender = resumeEntity.getGender();
         birthDate = resumeEntity.getBirthDate();
         email = resumeEntity.getEmail();
         phoneNumber = resumeEntity.getPhoneNumber();
         address = resumeEntity.getAddress();
-        education = resumeEntity.getEducation().getValue();
+        education = resumeEntity.getEducation();
         schoolName = resumeEntity.getSchoolName();
         portfolio = resumeEntity.getPortfolio();
 
@@ -104,7 +106,7 @@ public class ResumeReadDto {
         return this;
       }
 
-      public ResponseBuilder jobWant(String jobWant) {
+      public ResponseBuilder jobWant(JobCategory jobCategory) {
 
         this.jobWant = jobWant;
         return this;
@@ -146,7 +148,7 @@ public class ResumeReadDto {
         return this;
       }
 
-      public ResponseBuilder education(String education) {
+      public ResponseBuilder education(Education education) {
 
         this.education = education;
         return this;
@@ -169,7 +171,7 @@ public class ResumeReadDto {
         this.career = career.stream().map(e ->
             CareerDto.Response.builder()
                 .companyName(e.getCompanyName())
-                .jobCategory(e.getJobCategory().getValue())
+                .jobCategory(e.getJobCategory())
                 .startDate(e.getStartDate())
                 .endDate(e.getEndDate())
                 .calculatedCareer(e.getCalculatedCareer())
@@ -185,8 +187,7 @@ public class ResumeReadDto {
             CertificateDto.builder()
                 .certificateName(e.getCertificateName())
                 .certificateDate(e.getCertificateDate())
-                .build(
-                )
+                .build()
         ).collect(Collectors.toList());
 
         return this;
@@ -199,8 +200,7 @@ public class ResumeReadDto {
                 .experienceName(e.getExperienceName())
                 .startDate(e.getStartDate())
                 .endDate(e.getEndDate())
-                .build(
-                )
+                .build()
         ).collect(Collectors.toList());
 
         return this;
@@ -210,7 +210,6 @@ public class ResumeReadDto {
 
         this.techStack = techStack.stream()
             .map(ResumeTechStackEntity::getTechStackName)
-            .map(TechStack::getValue)
             .collect(Collectors.toList());
 
         return this;

--- a/src/main/java/com/ctrls/auto_enter_view/service/InterviewScheduleService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/InterviewScheduleService.java
@@ -7,7 +7,6 @@ import com.ctrls.auto_enter_view.entity.CompanyEntity;
 import com.ctrls.auto_enter_view.entity.InterviewScheduleEntity;
 import com.ctrls.auto_enter_view.entity.JobPostingEntity;
 import com.ctrls.auto_enter_view.enums.ErrorCode;
-import com.ctrls.auto_enter_view.enums.ResponseMessage;
 import com.ctrls.auto_enter_view.exception.CustomException;
 import com.ctrls.auto_enter_view.repository.CompanyRepository;
 import com.ctrls.auto_enter_view.repository.InterviewScheduleRepository;

--- a/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
@@ -77,6 +77,7 @@ public class JobPostingStepService {
    */
   @Transactional(readOnly = true)
   public List<JobPostingEveryInfoDto> getCandidatesListByStepId(String jobPostingKey) {
+
     List<JobPostingEveryInfoDto> jobPostingEveryInfoDtoList = new ArrayList<>();
 
     JobPostingEntity jobPosting = findJobPostingEntityByJobPostingKey(jobPostingKey);
@@ -211,11 +212,11 @@ public class JobPostingStepService {
   }
 
   // 이력서의 기술 스택 조회
-  private List<String> findTechStackByResumeKey(String resumeKey) {
+  private List<TechStack> findTechStackByResumeKey(String resumeKey) {
+
     return resumeTechStackRepository.findAllByResumeKey(resumeKey)
         .stream()
         .map(ResumeTechStackEntity::getTechStackName)
-        .map(TechStack::getValue)
         .collect(Collectors.toList());
   }
 
@@ -227,7 +228,7 @@ public class JobPostingStepService {
         candidateListEntity.getCandidateKey());
 
     // List<String>으로 TechStack의 value를 받아와서 넘겨줘야 함
-    List<String> techStack = findTechStackByResumeKey(resumeEntity.getResumeKey());
+    List<TechStack> techStack = findTechStackByResumeKey(resumeEntity.getResumeKey());
 
     InterviewScheduleParticipantsEntity interviewScheduleParticipantsEntity = interviewScheduleParticipantsRepository.findByJobPostingStepIdAndCandidateKey(
             stepId, candidateListEntity.getCandidateKey())
@@ -250,7 +251,7 @@ public class JobPostingStepService {
         candidateListEntity.getCandidateKey());
 
     // List<String>으로 TechStack의 value를 받아와서 넘겨줘야 함
-    List<String> techStack = findTechStackByResumeKey(resumeEntity.getResumeKey());
+    List<TechStack> techStack = findTechStackByResumeKey(resumeEntity.getResumeKey());
 
     InterviewScheduleEntity interviewScheduleEntity = interviewScheduleRepository.findByJobPostingStepId(
         stepId).orElseGet(InterviewScheduleEntity::new);
@@ -280,7 +281,7 @@ public class JobPostingStepService {
     ResumeEntity resumeEntity = findResumeEntityByCandidateKey(
         candidateListEntity.getCandidateKey());
 
-    List<String> techStack = findTechStackByResumeKey(resumeEntity.getResumeKey());
+    List<TechStack> techStack = findTechStackByResumeKey(resumeEntity.getResumeKey());
 
     return CandidateTechStackInterviewInfoDto.builder()
         .candidateKey(candidateListEntity.getCandidateKey())

--- a/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
@@ -77,7 +77,6 @@ public class JobPostingStepService {
    */
   @Transactional(readOnly = true)
   public List<JobPostingEveryInfoDto> getCandidatesListByStepId(String jobPostingKey) {
-
     List<JobPostingEveryInfoDto> jobPostingEveryInfoDtoList = new ArrayList<>();
 
     JobPostingEntity jobPosting = findJobPostingEntityByJobPostingKey(jobPostingKey);
@@ -212,11 +211,11 @@ public class JobPostingStepService {
   }
 
   // 이력서의 기술 스택 조회
-  private List<TechStack> findTechStackByResumeKey(String resumeKey) {
-
+  private List<String> findTechStackByResumeKey(String resumeKey) {
     return resumeTechStackRepository.findAllByResumeKey(resumeKey)
         .stream()
         .map(ResumeTechStackEntity::getTechStackName)
+        .map(TechStack::getValue)
         .collect(Collectors.toList());
   }
 
@@ -228,7 +227,7 @@ public class JobPostingStepService {
         candidateListEntity.getCandidateKey());
 
     // List<String>으로 TechStack의 value를 받아와서 넘겨줘야 함
-    List<TechStack> techStack = findTechStackByResumeKey(resumeEntity.getResumeKey());
+    List<String> techStack = findTechStackByResumeKey(resumeEntity.getResumeKey());
 
     InterviewScheduleParticipantsEntity interviewScheduleParticipantsEntity = interviewScheduleParticipantsRepository.findByJobPostingStepIdAndCandidateKey(
             stepId, candidateListEntity.getCandidateKey())
@@ -251,7 +250,7 @@ public class JobPostingStepService {
         candidateListEntity.getCandidateKey());
 
     // List<String>으로 TechStack의 value를 받아와서 넘겨줘야 함
-    List<TechStack> techStack = findTechStackByResumeKey(resumeEntity.getResumeKey());
+    List<String> techStack = findTechStackByResumeKey(resumeEntity.getResumeKey());
 
     InterviewScheduleEntity interviewScheduleEntity = interviewScheduleRepository.findByJobPostingStepId(
         stepId).orElseGet(InterviewScheduleEntity::new);
@@ -281,7 +280,7 @@ public class JobPostingStepService {
     ResumeEntity resumeEntity = findResumeEntityByCandidateKey(
         candidateListEntity.getCandidateKey());
 
-    List<TechStack> techStack = findTechStackByResumeKey(resumeEntity.getResumeKey());
+    List<String> techStack = findTechStackByResumeKey(resumeEntity.getResumeKey());
 
     return CandidateTechStackInterviewInfoDto.builder()
         .candidateKey(candidateListEntity.getCandidateKey())


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 직렬기 사용 없이 Enum 을 String 으로 변환하여 응답값으로 내려줌
- 빈 값을 조회할 때 null 이 제대로 표시되지 않고 null 상태의 Enum 에서 getValue() 함수 호출, null pointer exception 발생
- ResumeDto 에 `@Valid` 가 없어서 List<DTO> 에 대한 검증을 수행하지 않음

**TO-BE**
- 각 Enum 에 대한 Serializer 를 구성하여 일일이 String 으로 변환하는 로직이 필요없어짐
- 빈 값을 조회해서 null 이 되어도 getValue() 함수를 호출하지 않으므로 null pointer exception 예외 방지
- TechStack 변환기를 스프링 빈에 등록할 필요가 없으므로 `@Component` 어노테이션 삭제
- `@Valid` 를 추가하여 `private List<CareerDto.Request> career;` 와 같은 List<DTO> 검증 가능

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] API 테스트 