### PR TITLE
채용 공고 단계 이동 로직 수정, S3ImageUpload를 Component로 변경

### DIFF
--- a/src/main/java/com/ctrls/auto_enter_view/component/S3ImageUpload.java
+++ b/src/main/java/com/ctrls/auto_enter_view/component/S3ImageUpload.java
@@ -1,4 +1,4 @@
-package com.ctrls.auto_enter_view.service;
+package com.ctrls.auto_enter_view.component;
 
 import com.ctrls.auto_enter_view.enums.ErrorCode;
 import com.ctrls.auto_enter_view.exception.CustomException;
@@ -9,7 +9,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
@@ -19,8 +19,8 @@ import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
 @Slf4j
 @RequiredArgsConstructor
-@Service
-public class S3ImageUploadService {
+@Component
+public class S3ImageUpload {
 
   private final S3Client s3Client;
 

--- a/src/main/java/com/ctrls/auto_enter_view/controller/JobPostingStepController.java
+++ b/src/main/java/com/ctrls/auto_enter_view/controller/JobPostingStepController.java
@@ -50,7 +50,7 @@ public class JobPostingStepController {
       @RequestBody @Validated EditJobPostingStepDto request,
       @PathVariable String jobPostingKey,
       @AuthenticationPrincipal UserDetails userDetails) {
-    jobPostingStepService.editStepId(request.getCurrentStepId(), request.getCandidateKey(),
+    jobPostingStepService.editStepId(request.getCurrentStepId(), request.getCandidateKeys(),
         jobPostingKey, userDetails);
     return ResponseEntity.ok(ResponseMessage.SUCCESS_STEP_MOVEMENT.getMessage());
   }

--- a/src/main/java/com/ctrls/auto_enter_view/dto/jobPostingStep/EditJobPostingStepDto.java
+++ b/src/main/java/com/ctrls/auto_enter_view/dto/jobPostingStep/EditJobPostingStepDto.java
@@ -1,6 +1,7 @@
 package com.ctrls.auto_enter_view.dto.jobPostingStep;
 
-import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,6 +16,7 @@ public class EditJobPostingStepDto {
 
   private long currentStepId;
 
-  @NotBlank(message = "지원자 키는 필수 입력값 입니다.")
-  private List<String> candidateKey;
+  @NotEmpty(message = "지원자 키는 필수 입력값 입니다.")
+  @Size(min = 1, message = "최소 한 명의 지원자는 선택되어야 합니다.")
+  private List<String> candidateKeys;
 }

--- a/src/main/java/com/ctrls/auto_enter_view/dto/jobPostingStep/EditJobPostingStepDto.java
+++ b/src/main/java/com/ctrls/auto_enter_view/dto/jobPostingStep/EditJobPostingStepDto.java
@@ -1,6 +1,7 @@
 package com.ctrls.auto_enter_view.dto.jobPostingStep;
 
 import jakarta.validation.constraints.NotBlank;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,5 +16,5 @@ public class EditJobPostingStepDto {
   private long currentStepId;
 
   @NotBlank(message = "지원자 키는 필수 입력값 입니다.")
-  private String candidateKey;
+  private List<String> candidateKey;
 }

--- a/src/main/java/com/ctrls/auto_enter_view/enums/ErrorCode.java
+++ b/src/main/java/com/ctrls/auto_enter_view/enums/ErrorCode.java
@@ -48,7 +48,7 @@ public enum ErrorCode {
   JOB_POSTING_EXPIRED(404, "마감일이 지난 채용 공고 입니다."),
   BLACKLIST_TOKEN_ADD_FAILED(500, "블랙리스트 토큰 추가에 실패했습니다."),
   SCHEDULE_FAILED(500, "스케줄링에 실패하였습니다."),
-  UNSCHEDULE_FAILED(500, "스케줄링 취소에 실패하였습니다.");
+  UNSCHEDULE_FAILED(500, "스케줄링 취소에 실패하였습니다."),
   FAILED_MAIL_SCHEDULING(500, "메일 예약 등록을 실패했습니다."),
   FAILED_MAIL_UNSCHEDULING(500, "메일 예약 취소를 실패했습니다.");
   

--- a/src/main/java/com/ctrls/auto_enter_view/repository/CandidateListRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/CandidateListRepository.java
@@ -2,9 +2,6 @@ package com.ctrls.auto_enter_view.repository;
 
 import com.ctrls.auto_enter_view.entity.CandidateListEntity;
 import java.util.List;
-import java.util.Optional;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -16,8 +13,6 @@ public interface CandidateListRepository extends JpaRepository<CandidateListEnti
       Long jobPostingStepId);
 
   boolean existsByJobPostingKeyAndJobPostingStepId(String jobPostingKey, Long jobPostingStepId);
-
-  Page<CandidateListEntity> findAllByCandidateKey(String candidateKey, Pageable pageable);
 
   @Query("SELECT c.candidateKey FROM CandidateListEntity c WHERE c.jobPostingKey = :jobPostingKey AND c.jobPostingStepId = :stepId")
   List<String> findCandidateKeyByJobPostingKeyAndJobPostingStepId(String jobPostingKey,

--- a/src/main/java/com/ctrls/auto_enter_view/repository/CandidateListRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/CandidateListRepository.java
@@ -26,5 +26,5 @@ public interface CandidateListRepository extends JpaRepository<CandidateListEnti
   @Query("SELECT c.candidateName FROM CandidateListEntity c WHERE c.candidateKey = :candidateKey")
   String findCandidateNameByCandidateKey(String candidateKey);
 
-  Optional<CandidateListEntity> findByCandidateKeyAndJobPostingKey(String candidateKey, String jobPostingKey);
+  List<CandidateListEntity> findAllByCandidateKeyInAndJobPostingKey(List<String> candidateKeys, String jobPostingKey);
 }

--- a/src/main/java/com/ctrls/auto_enter_view/repository/JobPostingStepRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/JobPostingStepRepository.java
@@ -1,6 +1,5 @@
 package com.ctrls.auto_enter_view.repository;
 
-import com.ctrls.auto_enter_view.entity.JobPostingEntity;
 import com.ctrls.auto_enter_view.entity.JobPostingStepEntity;
 import java.util.List;
 import java.util.Optional;
@@ -11,8 +10,6 @@ import org.springframework.stereotype.Repository;
 public interface JobPostingStepRepository extends JpaRepository<JobPostingStepEntity, Long> {
 
   List<JobPostingStepEntity> findAllByJobPostingKey(String jobPostingKey);
-
-  boolean existsByIdAndJobPostingKey(Long stepId, String jobPostingKey);
 
   void deleteByJobPostingKey(String jobPostingKey);
 

--- a/src/main/java/com/ctrls/auto_enter_view/repository/JobPostingStepRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/JobPostingStepRepository.java
@@ -1,5 +1,6 @@
 package com.ctrls.auto_enter_view.repository;
 
+import com.ctrls.auto_enter_view.entity.JobPostingEntity;
 import com.ctrls.auto_enter_view.entity.JobPostingStepEntity;
 import java.util.List;
 import java.util.Optional;
@@ -19,5 +20,5 @@ public interface JobPostingStepRepository extends JpaRepository<JobPostingStepEn
 
   List<JobPostingStepEntity> findByJobPostingKey(String jobPostingKey);
 
-  Optional<JobPostingStepEntity> findByJobPostingKeyAndId(String jobPostingKey, Long nextStepId);
+  Optional<JobPostingStepEntity> findByJobPostingKeyAndId(String jobPostingKey, Long stepId);
 }

--- a/src/main/java/com/ctrls/auto_enter_view/service/CommonUserService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/CommonUserService.java
@@ -14,7 +14,6 @@ import com.ctrls.auto_enter_view.dto.common.SignInDto;
 import com.ctrls.auto_enter_view.entity.CandidateEntity;
 import com.ctrls.auto_enter_view.entity.CompanyEntity;
 import com.ctrls.auto_enter_view.enums.ErrorCode;
-import com.ctrls.auto_enter_view.enums.UserRole;
 import com.ctrls.auto_enter_view.exception.CustomException;
 import com.ctrls.auto_enter_view.repository.CandidateRepository;
 import com.ctrls.auto_enter_view.repository.CompanyInfoRepository;
@@ -56,7 +55,7 @@ public class CommonUserService {
    * @throws CustomException EMAIL_DUPLICATION : 이메일이 중복된 경우
    */
   public String checkDuplicateEmail(String email) {
-    
+
     if (!validateCompanyExistsByEmail(email) && !validateCandidateExistsByEmail(email)) {
       return USABLE_EMAIL.getMessage();
     } else {
@@ -242,9 +241,6 @@ public class CommonUserService {
    */
   public void changePassword(UserDetails userDetails, String key, Request request) {
 
-    UserDetails userDetails = (UserDetails) SecurityContextHolder.getContext().getAuthentication()
-        .getPrincipal();
-
     Collection<? extends GrantedAuthority> authorities = userDetails.getAuthorities();
 
     for (GrantedAuthority authority : authorities) {
@@ -284,6 +280,7 @@ public class CommonUserService {
   /**
    * 회원 탈퇴
    *
+   * @param userDetails 로그인 된 사용자 정보
    * @param key CompanyKey 또는 CandidateKey
    * @throws CustomException USER_NOT_FOUND : 사용자를 찾을 수 없는 경우
    * @throws CustomException KEY_NOT_MATCH : 키가 일치하지 않는 경우

--- a/src/main/java/com/ctrls/auto_enter_view/service/JobPostingImageService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/JobPostingImageService.java
@@ -1,5 +1,6 @@
 package com.ctrls.auto_enter_view.service;
 
+import com.ctrls.auto_enter_view.component.S3ImageUpload;
 import com.ctrls.auto_enter_view.dto.jobPosting.JobPostingDto;
 import com.ctrls.auto_enter_view.entity.JobPostingImageEntity;
 import com.ctrls.auto_enter_view.repository.JobPostingImageRepository;
@@ -15,7 +16,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class JobPostingImageService {
 
   private final JobPostingImageRepository jobPostingImageRepository;
-  private final S3ImageUploadService s3ImageUploadService;
+  private final S3ImageUpload s3ImageUpload;
 
   /**
    * 이미지 파일 업로드
@@ -34,10 +35,10 @@ public class JobPostingImageService {
 
     // 기존 이미지가 있다면 삭제
     if (jobPostingImage.getCompanyImageUrl() != null) {
-      s3ImageUploadService.deleteImage(jobPostingImage.getCompanyImageUrl());
+      s3ImageUpload.deleteImage(jobPostingImage.getCompanyImageUrl());
     }
 
-    String imageUrl = s3ImageUploadService.uploadImage(image, "job-posting-images");
+    String imageUrl = s3ImageUpload.uploadImage(image, "job-posting-images");
     jobPostingImage.updateCompanyImageUrl(imageUrl);
     jobPostingImageRepository.save(jobPostingImage);
 
@@ -67,7 +68,7 @@ public class JobPostingImageService {
     jobPostingImageRepository.findByJobPostingKey(jobPostingKey)
         .ifPresent(image -> {
           String imageUrl = image.getCompanyImageUrl();
-          s3ImageUploadService.deleteImage(imageUrl);
+          s3ImageUpload.deleteImage(imageUrl);
           jobPostingImageRepository.delete(image);
         });
   }

--- a/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
@@ -53,6 +53,12 @@ public class JobPostingStepService {
   private final InterviewScheduleRepository interviewScheduleRepository;
   private final InterviewScheduleParticipantsRepository interviewScheduleParticipantsRepository;
 
+  /**
+   * 채용 공고 단계 생성하기
+   *
+   * @param entity JobPostingEntity
+   * @param request JobPostingDto.Request
+   */
   public void createJobPostingStep(JobPostingEntity entity, JobPostingDto.Request request) {
 
     List<String> jobPostingStep = request.getJobPostingStep();
@@ -72,6 +78,7 @@ public class JobPostingStepService {
    *
    * @param jobPostingKey 채용공고 KEY
    * @return 채용 단계의 모든 정보 리스트
+   * @throws CustomException USER_NOT_FOUND, JOB_POSTING_NOT_FOUND, RESUME_NOT_FOUND
    */
   @Transactional(readOnly = true)
   public List<JobPostingEveryInfoDto> getCandidatesListByStepId(UserDetails userDetails,
@@ -174,21 +181,39 @@ public class JobPostingStepService {
     return jobPostingEveryInfoDtoList;
   }
 
-  // 채용공고 key로 채용공고 entity 찾기
+  /**
+   * 채용공고 key로 채용공고 entity 찾기
+   *
+   * @param jobPostingKey 채용 공고 PK
+   * @return JobPostingEntity
+   * @throws CustomException JOB_POSTING_NOT_FOUND : 채용 공고를 찾을 수 없는 경우
+   */
   public JobPostingEntity findJobPostingEntityByJobPostingKey(String jobPostingKey) {
 
     return jobPostingRepository.findByJobPostingKey(jobPostingKey)
         .orElseThrow(() -> new CustomException(JOB_POSTING_NOT_FOUND));
   }
 
-  // 사용자 인증 정보로 회사 entity 찾기
+  /**
+   * 사용자 인증 정보로 회사 entity 찾기
+   *
+   * @param userDetails 로그인 된 사용자 정보
+   * @return CompanyEntity
+   * @throws CustomException USER_NOT_FOUND : 사용자를 찾을 수 없는 경우
+   */
   private CompanyEntity findCompanyByPrincipal(UserDetails userDetails) {
 
     return companyRepository.findByEmail(userDetails.getUsername())
         .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
   }
 
-  // 채용 공고를 올린 회사 본인인지 확인
+  /**
+   * 채용 공고를 올린 회사 본인인지 확인
+   *
+   * @param company CompanyEntity
+   * @param jobPosting JobPostingEntity
+   * @throws CustomException USER_NOT_FOUND : 사용자를 찾을 수 없는 경우
+   */
   private void verifyCompanyOwnership(CompanyEntity company, JobPostingEntity jobPosting) {
 
     if (!company.getCompanyKey().equals(jobPosting.getCompanyKey())) {
@@ -196,20 +221,37 @@ public class JobPostingStepService {
     }
   }
 
-  // 해당 채용공고에 지정된 단계에 속하는 지원자 목록 조회
+  /**
+   * 해당 채용공고에 지정된 단계에 속하는 지원자 목록 조회
+   *
+   * @param jobPostingKey 채용 공고 PK
+   * @param stepId 채용 단계 PK
+   * @return List<CandidateListEntity>
+   */
   private List<CandidateListEntity> getCandidateList(String jobPostingKey, Long stepId) {
 
     return candidateListRepository.findAllByJobPostingKeyAndJobPostingStepId(jobPostingKey, stepId);
   }
 
-  // 지원자의 이력서 entity 조회
+  /**
+   * 지원자의 이력서 entity 조회
+   *
+   * @param candidateKey 지원자 PK
+   * @return ResumeEntity
+   * @throws CustomException RESUME_NOT_FOUND : 이력서를 찾을 수 없는 경우
+   */
   private ResumeEntity findResumeEntityByCandidateKey(String candidateKey) {
 
     return resumeRepository.findByCandidateKey(candidateKey)
         .orElseThrow(() -> new CustomException(RESUME_NOT_FOUND));
   }
 
-  // 이력서의 기술 스택 조회
+  /**
+   * 이력서의 기술 스택 조회
+   *
+   * @param resumeKey 이력서 PK
+   * @return List<TechStack>
+   */
   private List<TechStack> findTechStackByResumeKey(String resumeKey) {
 
     return resumeTechStackRepository.findAllByResumeKey(resumeKey)
@@ -218,7 +260,13 @@ public class JobPostingStepService {
         .collect(Collectors.toList());
   }
 
-  // 면접 : CandidateListEntity & stepId -> CandidateTechStackInterviewInfoDto 매핑
+  /**
+   * 면접 : CandidateListEntity & stepId -> CandidateTechStackInterviewInfoDto 매핑
+   *
+   * @param candidateListEntity CandidateListEntity
+   * @param stepId 채용 공고 단계 PK
+   * @return CandidateTechStackInterviewInfoDto.Response
+   */
   private CandidateTechStackInterviewInfoDto mapToCandidateTechStackListDtoInterview(
       CandidateListEntity candidateListEntity, Long stepId) {
 
@@ -240,7 +288,13 @@ public class JobPostingStepService {
         .build();
   }
 
-  // 과제 : CandidateListEntity & stepId -> CandidateTechStackInterviewInfoDto 매핑
+  /**
+   * CandidateListEntity & stepId -> CandidateTechStackInterviewInfoDto 매핑
+   *
+   * @param candidateListEntity CandidateListEntity
+   * @param stepId 채용 공고 단계 PK
+   * @return CandidateTechStackInterviewInfoDto.Response
+   */
   private CandidateTechStackInterviewInfoDto mapToCandidateTechStackListDtoTask(
       CandidateListEntity candidateListEntity, Long stepId) {
 
@@ -270,7 +324,12 @@ public class JobPostingStepService {
         .build();
   }
 
-  // CandidateListEntity & stepId -> CandidateTechStackInterviewInfoDto 매핑
+  /**
+   * CandidateListEntity & stepId -> CandidateTechStackInterviewInfoDto 매핑
+   *
+   * @param candidateListEntity CandidateListEntity
+   * @return CandidateTechStackInterviewInfoDto.Response
+   */
   private CandidateTechStackInterviewInfoDto mapToCandidateTechStackListDtoNothing(
       CandidateListEntity candidateListEntity) {
 
@@ -288,12 +347,22 @@ public class JobPostingStepService {
         .build();
   }
 
+  /**
+   *채용 공고 단계 삭제하기
+   *
+   * @param jobPostingKey 채용 공고 PK
+   */
   public void deleteJobPostingStep(String jobPostingKey) {
 
     jobPostingStepRepository.deleteByJobPostingKey(jobPostingKey);
   }
 
-  // 채용 공고 key -> 채용 단계 조회
+  /**
+   * 채용 공고 key -> 채용 단계 조회
+   *
+   * @param jobPostingKey 채용 공고 PK
+   * @return 채용 단계 리스트 List<step>
+   */
   public List<String> getStepByJobPostingKey(String jobPostingKey) {
 
     List<JobPostingStepEntity> entities = jobPostingStepRepository.findByJobPostingKey(
@@ -307,9 +376,17 @@ public class JobPostingStepService {
     return step;
   }
 
-  // 채용 단계 올리기
+  /**
+   * 채용 단계 올리기
+   *
+   * @param currentStepId 현재 채용 공고 단계 ID (PK)
+   * @param candidateKeys 지원자 PK
+   * @param jobPostingKey 채용 공고 PK
+   * @param userDetails 로그인 된 사용자 정보
+   * @throws CustomException COMPANY_NOT_FOUND, JOB_POSTING_NOT_FOUND, NO_AUTHORITY, NEXT_STEP_NOT_FOUND, CANDIDATE_NOT_FOUND
+   */
   @Transactional
-  public void editStepId(Long currentStepId, String candidateKey, String jobPostingKey,
+  public void editStepId(Long currentStepId, List<String> candidateKeys, String jobPostingKey,
       UserDetails userDetails) {
 
     CompanyEntity companyEntity = companyRepository.findByEmail(userDetails.getUsername())
@@ -323,20 +400,27 @@ public class JobPostingStepService {
       throw new CustomException(ErrorCode.NO_AUTHORITY);
     }
 
-    // 지원자 정보 조회
-    CandidateListEntity candidateListEntity = candidateListRepository.findByCandidateKeyAndJobPostingKey(
-            candidateKey, jobPostingKey)
-        .orElseThrow(() -> new CustomException(ErrorCode.CANDIDATE_NOT_FOUND));
-
     // 다음 단계 ID 계산
     Long nextStepId = currentStepId + 1;
 
     // 다음 단계가 존재하는지 확인
-    JobPostingStepEntity nextStep = jobPostingStepRepository.findByJobPostingKeyAndId(jobPostingKey,
-            nextStepId)
-        .orElseThrow(() -> new CustomException(ErrorCode.NEXT_STEP_NOT_FOUND));
+    Optional<JobPostingStepEntity> nextStepOptional = jobPostingStepRepository.findByJobPostingKeyAndId(jobPostingEntity.getJobPostingKey(), nextStepId);
+
+    if (nextStepOptional.isEmpty()) {
+      throw new CustomException(ErrorCode.NEXT_STEP_NOT_FOUND);
+    }
+
+    // 지원자 정보 조회
+    List<CandidateListEntity> candidateListEntities = candidateListRepository
+        .findAllByCandidateKeyInAndJobPostingKey(candidateKeys, jobPostingKey);
+
+    if (candidateListEntities.size() != candidateKeys.size()) {
+      throw new CustomException(ErrorCode.CANDIDATE_NOT_FOUND);
+    }
 
     // 지원자의 단계 ID 업데이트
-    candidateListEntity.updateJobPostingStepId(nextStepId);
+    for (CandidateListEntity candidate : candidateListEntities) {
+      candidate.updateJobPostingStepId(nextStepId);
+    }
   }
 }

--- a/src/main/java/com/ctrls/auto_enter_view/service/ResumeImageService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/ResumeImageService.java
@@ -1,5 +1,6 @@
 package com.ctrls.auto_enter_view.service;
 
+import com.ctrls.auto_enter_view.component.S3ImageUpload;
 import com.ctrls.auto_enter_view.dto.resume.ResumeDto;
 import com.ctrls.auto_enter_view.entity.ResumeImageEntity;
 import com.ctrls.auto_enter_view.repository.ResumeImageRepository;
@@ -18,7 +19,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class ResumeImageService {
 
   private final ResumeImageRepository resumeImageRepository;
-  private final S3ImageUploadService s3ImageUploadService;
+  private final S3ImageUpload s3ImageUpload;
   private final ResumeRepository resumeRepository;
 
   /**
@@ -37,10 +38,10 @@ public class ResumeImageService {
 
     // 기존 이미지가 있고, 새 이미지가 제공된 경우에만 기존 이미지 삭제
     if (resumeImage.getResumeImageUrl() != null) {
-      s3ImageUploadService.deleteImage(resumeImage.getResumeImageUrl());
+      s3ImageUpload.deleteImage(resumeImage.getResumeImageUrl());
     }
 
-    String imageUrl = s3ImageUploadService.uploadImage(image, "resume-images");
+    String imageUrl = s3ImageUpload.uploadImage(image, "resume-images");
     resumeImage.updateResumeImageUrl(imageUrl);
     resumeImageRepository.save(resumeImage);
 
@@ -75,7 +76,7 @@ public class ResumeImageService {
           resumeImageRepository.findByResumeKey(resumeKey)
               .ifPresent(image -> {
                 String imageUrl = image.getResumeImageUrl();
-                s3ImageUploadService.deleteImage(imageUrl);
+                s3ImageUpload.deleteImage(imageUrl);
                 resumeImageRepository.delete(image);
               });
         });


### PR DESCRIPTION
### 변경사항

**AS-IS**
- S3ImageUploadService를 범용적으로 사용 
- 채용 공고 단계를 지원자 1명 씩 이동
- JobPostingStepService에 설명이 부족한 메서드들이 존재

**TO-BE**
- S3ImageUpload를 Component로 변경
- 채용 공고 단계를 지원자 한꺼번에 이동하도록 수정
- 채용 공고 단계변경에서 String으로 받아오는 CandidateKey를 List<String>으로 변경
- JobPostingStepService 메서드에 주석으로 설명추가
- 사용하지 않는 메서드와 import문 삭제
