### PR TITLE
메인에 잘못 머지한 코드들 복구

### DIFF
--- a/src/test/java/com/ctrls/auto_enter_view/service/BlacklistTokenServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/BlacklistTokenServiceTest.java
@@ -1,11 +1,17 @@
 package com.ctrls.auto_enter_view.service;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.ctrls.auto_enter_view.enums.ErrorCode;
+import com.ctrls.auto_enter_view.exception.CustomException;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -35,7 +41,7 @@ class BlacklistTokenServiceTest {
   }
 
   @Test
-  @DisplayName("블랙리스트에 토큰 추가 테스트")
+  @DisplayName("블랙리스트에 토큰 추가하기 - 성공")
   void addToBlacklist() {
     // given
     String token = "Bearer testToken";
@@ -50,7 +56,24 @@ class BlacklistTokenServiceTest {
   }
 
   @Test
-  @DisplayName("블랙리스트에 토큰 존재여부 확인 테스트")
+  @DisplayName("블랙리스트에 토큰 추가하기 - 실패")
+  void addToBlacklistException() {
+    // given
+    String token = "Bearer testToken";
+    String substringToken = "testToken";
+    doThrow(new RuntimeException()).when(valueOperations).set(substringToken, "logout", 60, TimeUnit.MINUTES);
+
+    // when
+    CustomException exception = assertThrows(CustomException.class, () -> blacklistTokenService.addToBlacklist(token));
+
+    // then
+    assertNotNull(exception);
+    assertEquals(ErrorCode.BLACKLIST_TOKEN_ADD_FAILED, exception.getErrorCode());
+    verify(valueOperations, times(1)).set(substringToken, "logout", 60, TimeUnit.MINUTES);
+  }
+
+  @Test
+  @DisplayName("블랙리스트에 토큰 존재여부 확인")
   void isTokenBlacklist() {
     // given
     String token = "testToken";

--- a/src/test/java/com/ctrls/auto_enter_view/service/CandidateServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/CandidateServiceTest.java
@@ -1,38 +1,42 @@
 package com.ctrls.auto_enter_view.service;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.BDDMockito.given;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.ctrls.auto_enter_view.dto.candidate.FindEmailDto.Request;
-import com.ctrls.auto_enter_view.dto.candidate.FindEmailDto.Response;
-import com.ctrls.auto_enter_view.dto.candidate.SignUpDto;
+import com.ctrls.auto_enter_view.dto.candidate.CandidateApplyDto;
+import com.ctrls.auto_enter_view.entity.AppliedJobPostingEntity;
 import com.ctrls.auto_enter_view.entity.CandidateEntity;
 import com.ctrls.auto_enter_view.enums.ErrorCode;
-import com.ctrls.auto_enter_view.enums.UserRole;
 import com.ctrls.auto_enter_view.exception.CustomException;
-import com.ctrls.auto_enter_view.repository.CandidateListRepository;
+import com.ctrls.auto_enter_view.repository.AppliedJobPostingRepository;
 import com.ctrls.auto_enter_view.repository.CandidateRepository;
-import com.ctrls.auto_enter_view.repository.CompanyRepository;
-import com.ctrls.auto_enter_view.repository.JobPostingRepository;
+import com.ctrls.auto_enter_view.repository.ResumeRepository;
 import com.ctrls.auto_enter_view.util.KeyGenerator;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @ExtendWith(MockitoExtension.class)
 public class CandidateServiceTest {
@@ -41,16 +45,10 @@ public class CandidateServiceTest {
   private CandidateRepository candidateRepository;
 
   @Mock
-  private CandidateListRepository candidateListRepository;
+  private ResumeRepository resumeRepository;
 
   @Mock
-  private JobPostingRepository jobPostingRepository;
-
-  @Mock
-  private CompanyRepository companyRepository;
-
-  @Mock
-  private PasswordEncoder passwordEncoder;
+  private AppliedJobPostingRepository appliedJobPostingRepository;
 
   @Mock
   private KeyGenerator keyGenerator;
@@ -66,259 +64,136 @@ public class CandidateServiceTest {
         new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities()));
   }
 
+
   @Test
-  @DisplayName("회원가입 성공 테스트")
-  void createCandidateTest() {
+  @DisplayName("이력서 존재 여부 확인 - 이력서가 존재하는 경우")
+  void hasResumeWhenResumeExists() {
     // given
-    SignUpDto.Request request = SignUpDto.Request.builder()
-        .name("name")
-        .email("email@example.com")
-        .password("password")
-        .phoneNumber("010-1111-1111")
-        .build();
+    String mockedCompanyKey = "companyKey";
+    when(keyGenerator.generateKey()).thenReturn(mockedCompanyKey);
+    String companyKey = keyGenerator.generateKey();
 
-    String encodedPassword = "encodedPassword";
-
-    SignUpDto.Response expectedResponse = SignUpDto.Response.builder()
-        .email("email@example.com")
-        .name("name")
-        .build();
-
-    when(passwordEncoder.encode(request.getPassword())).thenReturn(encodedPassword);
-
-    ArgumentCaptor<CandidateEntity> captor = ArgumentCaptor.forClass(CandidateEntity.class);
+    when(resumeRepository.existsByCandidateKey(companyKey)).thenReturn(true);
 
     // when
-    SignUpDto.Response response = candidateService.signUp(request);
+    boolean result = candidateService.hasResume(companyKey);
 
     // then
-    verify(candidateRepository, times(1)).save(captor.capture());
-    CandidateEntity capturedCandidate = captor.getValue();
-
-    assertEquals(request.getName(), capturedCandidate.getName());
-    assertEquals(request.getEmail(), capturedCandidate.getEmail());
-    assertEquals(encodedPassword, capturedCandidate.getPassword());
-    assertEquals(request.getPhoneNumber(), capturedCandidate.getPhoneNumber());
-
-    assertEquals(expectedResponse.getEmail(), response.getEmail());
-    assertEquals(expectedResponse.getName(), response.getName());
+    assertTrue(result);
+    verify(resumeRepository, times(1)).existsByCandidateKey(companyKey);
   }
 
   @Test
-  @DisplayName("회원가입 실패 테스트 -> EMAIL_DUPLICATION")
-  void emailDuplicationExceptionTest() {
+  @DisplayName("이력서 존재 여부 확인 - 이력서가 존재하지 않는 경우")
+  void hasResumeWhenResumeDoesNotExist() {
     // given
-    SignUpDto.Request request = SignUpDto.Request.builder()
-        .name("name")
-        .email("email@example.com")
-        .password("password")
-        .phoneNumber("010-1111-1111")
-        .build();
+    String mockedCandidateKey = "candidateKey";
+    when(keyGenerator.generateKey()).thenReturn(mockedCandidateKey);
+    String candidateKey = keyGenerator.generateKey();
 
-    when(candidateRepository.existsByEmail("email@example.com")).thenReturn(true);
+    when(resumeRepository.existsByCandidateKey(candidateKey)).thenReturn(false);
 
     // when
-    CustomException customException = assertThrows(CustomException.class,
-        () -> candidateService.signUp(request));
+    boolean result = candidateService.hasResume(candidateKey);
 
     // then
-    assertEquals(ErrorCode.EMAIL_DUPLICATION, customException.getErrorCode());
-
+    assertFalse(result);
+    verify(resumeRepository, times(1)).existsByCandidateKey(candidateKey);
   }
 
   @Test
-  void findEmail_Success() {
-
+  @DisplayName("지원자가 지원한 채용 공고 조회 테스트 - 성공")
+  void getApplyJobPostingsSuccessTest() {
     // given
-    Request request = Request.builder()
-        .name("testName")
-        .phoneNumber("010-0000-0000")
-        .build();
+    String email = "test@example.com";
+    String mockedCandidateKey = "candidateKey";
+    when(keyGenerator.generateKey()).thenReturn(mockedCandidateKey);
+    String candidateKey = keyGenerator.generateKey();
+    int page = 1;
+    int size = 20;
+    Pageable pageable = PageRequest.of(page - 1, size);
 
     CandidateEntity candidateEntity = CandidateEntity.builder()
-        .email("test@naver.com")
+        .candidateKey(candidateKey)
+        .email(email)
         .build();
 
-    // when
-    given(candidateRepository.findByNameAndPhoneNumber(request.getName(),
-        request.getPhoneNumber())).willReturn(Optional.of(candidateEntity));
+    AppliedJobPostingEntity appliedJobPostingEntity1 = AppliedJobPostingEntity.builder()
+        .candidateKey(candidateKey)
+        .jobPostingKey("jobPostingKey1")
+        .build();
 
-    // execute
-    Response response = candidateService.findEmail(request);
+    AppliedJobPostingEntity appliedJobPostingEntity2 = AppliedJobPostingEntity.builder()
+        .candidateKey(candidateKey)
+        .jobPostingKey("jobPostingKey2")
+        .build();
+
+    List<AppliedJobPostingEntity> appliedJobPostingEntities = Arrays.asList(
+        appliedJobPostingEntity1, appliedJobPostingEntity2);
+    Page<AppliedJobPostingEntity> appliedJobPostingPage = new PageImpl<>(
+        appliedJobPostingEntities, pageable, appliedJobPostingEntities.size());
+
+    when(candidateRepository.findByEmail(email)).thenReturn(Optional.of(candidateEntity));
+    when(appliedJobPostingRepository.findAllByCandidateKey(candidateKey, pageable))
+        .thenReturn(appliedJobPostingPage);
+
+    // when
+    CandidateApplyDto.Response response = candidateService.getApplyJobPostings(
+        new User(email, "", Collections.emptyList()), candidateKey, page, size);
 
     // then
-    assertEquals(candidateEntity.getEmail(), response.getEmail());
+    assertEquals(2, response.getAppliedJobPostingsList().size());
+    assertEquals(1, response.getTotalPages());
+    assertEquals(2, response.getTotalElements());
   }
 
   @Test
-  void findEmail_Failure_EmailNotFound() {
-
+  @DisplayName("지원자가 지원한 채용 공고 조회 테스트 - 실패 : 가입된 지원자를 찾을 수 없음")
+  void getApplyJobPostingsFailCandidateNotFoundTest() {
     // given
-    Request request = Request.builder()
-        .name("testName")
-        .phoneNumber("010-0000-0000")
-        .build();
+    String email = "test@example.com";
+    String mockedCandidateKey = "candidateKey";
+    when(keyGenerator.generateKey()).thenReturn(mockedCandidateKey);
+    String candidateKey = keyGenerator.generateKey();
+    int page = 1;
+    int size = 20;
+
+    when(candidateRepository.findByEmail(email)).thenReturn(Optional.empty());
 
     // when
-    given(candidateRepository.findByNameAndPhoneNumber(request.getName(),
-        request.getPhoneNumber())).willReturn(Optional.empty());
+    Throwable throwable = catchThrowable(() -> candidateService.getApplyJobPostings(
+        new User(email, "", Collections.emptyList()), candidateKey, page, size));
 
     // then
-    CustomException exception = assertThrows(CustomException.class, () -> {
-      // execute
-      candidateService.findEmail(request);
-    });
-
-    assertEquals(ErrorCode.USER_NOT_FOUND_BY_NAME_AND_PHONE, exception.getErrorCode());
+    assertThat(throwable).isInstanceOf(CustomException.class);
+    assertThat(((CustomException) throwable).getErrorCode()).isEqualTo(
+        ErrorCode.CANDIDATE_NOT_FOUND);
   }
 
-//  @Test
-//  @DisplayName("지원자가 지원한 채용 공고 조회 테스트 - 성공")
-//  void getApplyJobPostingsSuccessTest() {
-//    // given
-//    String candidateKey = "candidateKey";
-//    String jobPostingKey1 = "jobPostingKey1";
-//    String jobPostingKey2 = "jobPostingKey2";
-//    String companyKey1 = "companyKey1";
-//    String companyKey2 = "companyKey2";
-//    String companyName1 = "companyName1";
-//    String companyName2 = "companyName2";
-//    int page = 1;
-//    int size = 20;
-//    Pageable pageable = PageRequest.of(page - 1, size);
-//
-//    CandidateListEntity candidateListEntity1 = CandidateListEntity.builder()
-//        .candidateKey(candidateKey)
-//        .jobPostingKey(jobPostingKey1)
-//        .build();
-//
-//    CandidateListEntity candidateListEntity2 = CandidateListEntity.builder()
-//        .candidateKey(candidateKey)
-//        .jobPostingKey(jobPostingKey2)
-//        .build();
-//
-//    List<CandidateListEntity> candidateListEntities = Arrays.asList(candidateListEntity1,
-//        candidateListEntity2);
-//
-//    JobPostingEntity jobPostingEntity1 = JobPostingEntity.builder()
-//        .jobPostingKey(jobPostingKey1)
-//        .companyKey(companyKey1)
-//        .build();
-//
-//    JobPostingEntity jobPostingEntity2 = JobPostingEntity.builder()
-//        .jobPostingKey(jobPostingKey2)
-//        .companyKey(companyKey2)
-//        .build();
-//
-//    CompanyEntity companyEntity1 = CompanyEntity.builder()
-//        .companyKey(companyKey1)
-//        .companyName(companyName1)
-//        .build();
-//
-//    CompanyEntity companyEntity2 = CompanyEntity.builder()
-//        .companyKey(companyKey2)
-//        .companyName(companyName2)
-//        .build();
-//
-//    given(candidateListRepository.findAllByCandidateKey(candidateKey, pageable))
-//        .willReturn(new PageImpl<>(candidateListEntities, pageable, candidateListEntities.size()));
-//    given(jobPostingRepository.findByJobPostingKey(jobPostingKey1)).willReturn(
-//        Optional.of(jobPostingEntity1));
-//    given(jobPostingRepository.findByJobPostingKey(jobPostingKey2)).willReturn(
-//        Optional.of(jobPostingEntity2));
-//    given(companyRepository.findByCompanyKey(companyKey1)).willReturn(Optional.of(companyEntity1));
-//    given(companyRepository.findByCompanyKey(companyKey2)).willReturn(Optional.of(companyEntity2));
-//
-//    // when
-//    CandidateApplyDto.Response response = candidateService.getApplyJobPostings(candidateKey, page,
-//        size);
-//
-//    // then
-//    assertEquals(2, response.getApplyJobPostingsList().size());
-//    assertEquals(1, response.getTotalPages());
-//    assertEquals(2, response.getTotalElements());
-//
-//    CandidateApplyDto.ApplyInfo applyInfo1 = response.getApplyJobPostingsList().get(0);
-//    assertEquals(jobPostingEntity1.getJobPostingKey(), applyInfo1.getJobPostingKey());
-//    assertEquals(companyName1, applyInfo1.getCompanyName());
-//
-//    CandidateApplyDto.ApplyInfo applyInfo2 = response.getApplyJobPostingsList().get(1);
-//    assertEquals(jobPostingEntity2.getJobPostingKey(), applyInfo2.getJobPostingKey());
-//    assertEquals(companyName2, applyInfo2.getCompanyName());
-//  }
+  @Test
+  @DisplayName("지원자가 지원한 채용 공고 조회 테스트 - 실패 : 권한 없음")
+  void getApplyJobPostingsFailNoAuthorityTest() {
+    // given
+    String email = "test@example.com";
+    String mockedCandidateKey = "candidateKey";
+    when(keyGenerator.generateKey()).thenReturn(mockedCandidateKey);
+    String candidateKey = keyGenerator.generateKey();
+    int page = 1;
+    int size = 20;
 
-//  @Test
-//  @DisplayName("지원자가 지원한 채용 공고 조회 테스트 - 실패 : 채용 공고 찾을 수 없음")
-//  void getApplyJobPostingsFailJobPostingNotFoundTest() {
-//    // given
-//    String candidateKey = "candidateKey";
-//    String jobPostingKey = "jobPostingKey";
-//    int page = 1;
-//    int size = 20;
-//    Pageable pageable = PageRequest.of(page - 1, size);
-//
-//    CandidateListEntity candidateListEntity = CandidateListEntity.builder()
-//        .candidateKey(candidateKey)
-//        .jobPostingKey(jobPostingKey)
-//        .build();
-//
-//    List<CandidateListEntity> candidateListEntities = Collections.singletonList(
-//        candidateListEntity);
-//    Page<CandidateListEntity> candidateListPage = new PageImpl<>(candidateListEntities, pageable,
-//        candidateListEntities.size());
-//
-//    given(candidateListRepository.findAllByCandidateKey(candidateKey, pageable)).willReturn(
-//        candidateListPage);
-//    given(jobPostingRepository.findByJobPostingKey(jobPostingKey)).willReturn(Optional.empty());
-//
-//    // when
-//    Throwable throwable = catchThrowable(
-//        () -> candidateService.getApplyJobPostings(candidateKey, page, size));
-//
-//    // then
-//    assertThat(throwable).isInstanceOf(CustomException.class);
-//    assertThat(((CustomException) throwable).getErrorCode()).isEqualTo(
-//        ErrorCode.JOB_POSTING_NOT_FOUND);
-//  }
+    CandidateEntity candidateEntity = CandidateEntity.builder()
+        .candidateKey("anotherCandidateKey")
+        .email(email)
+        .build();
 
-//  @Test
-//  @DisplayName("지원자가 지원한 채용 공고 조회 테스트 - 실패 : 회사 찾을 수 없음")
-//  void getApplyJobPostingsFailCompanyNotFoundTest() {
-//    // given
-//    String candidateKey = "candidateKey";
-//    String jobPostingKey = "jobPostingKey";
-//    String companyKey = "companyKey";
-//    int page = 1;
-//    int size = 20;
-//    Pageable pageable = PageRequest.of(page - 1, size);
-//
-//    CandidateListEntity candidateListEntity = CandidateListEntity.builder()
-//        .candidateKey(candidateKey)
-//        .jobPostingKey(jobPostingKey)
-//        .build();
-//
-//    List<CandidateListEntity> candidateListEntities = Collections.singletonList(
-//        candidateListEntity);
-//    Page<CandidateListEntity> candidateListPage = new PageImpl<>(candidateListEntities, pageable,
-//        candidateListEntities.size());
-//
-//    JobPostingEntity jobPostingEntity = JobPostingEntity.builder()
-//        .jobPostingKey(jobPostingKey)
-//        .companyKey(companyKey)
-//        .build();
-//
-//    given(candidateListRepository.findAllByCandidateKey(candidateKey, pageable)).willReturn(
-//        candidateListPage);
-//    given(jobPostingRepository.findByJobPostingKey(jobPostingKey)).willReturn(
-//        Optional.of(jobPostingEntity));
-//    given(companyRepository.findByCompanyKey(companyKey)).willReturn(Optional.empty());
-//
-//    // when
-//    Throwable throwable = catchThrowable(
-//        () -> candidateService.getApplyJobPostings(candidateKey, page, size));
-//
-//    // then
-//    assertThat(throwable).isInstanceOf(CustomException.class);
-//    assertThat(((CustomException) throwable).getErrorCode()).isEqualTo(ErrorCode.COMPANY_NOT_FOUND);
-//  }
+    when(candidateRepository.findByEmail(email)).thenReturn(Optional.of(candidateEntity));
+
+    // when
+    Throwable throwable = catchThrowable(() -> candidateService.getApplyJobPostings(
+        new User(email, "", Collections.emptyList()), candidateKey, page, size));
+
+    // then
+    assertThat(throwable).isInstanceOf(CustomException.class);
+    assertThat(((CustomException) throwable).getErrorCode()).isEqualTo(ErrorCode.NO_AUTHORITY);
+  }
 }

--- a/src/test/java/com/ctrls/auto_enter_view/service/CommonUserServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/CommonUserServiceTest.java
@@ -25,7 +25,6 @@ import com.ctrls.auto_enter_view.enums.UserRole;
 import com.ctrls.auto_enter_view.exception.CustomException;
 import com.ctrls.auto_enter_view.repository.CandidateRepository;
 import com.ctrls.auto_enter_view.repository.CompanyRepository;
-import com.ctrls.auto_enter_view.security.JwtTokenProvider;
 import com.ctrls.auto_enter_view.util.KeyGenerator;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -60,9 +59,6 @@ class CommonUserServiceTest {
 
   @Mock
   private ValueOperations<String, String> valueOperations;
-
-  @Mock
-  private JwtTokenProvider jwtTokenProvider;
 
   @Mock
   private BlacklistTokenService blacklistTokenService;

--- a/src/test/java/com/ctrls/auto_enter_view/service/CommonUserServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/CommonUserServiceTest.java
@@ -26,6 +26,7 @@ import com.ctrls.auto_enter_view.exception.CustomException;
 import com.ctrls.auto_enter_view.repository.CandidateRepository;
 import com.ctrls.auto_enter_view.repository.CompanyRepository;
 import com.ctrls.auto_enter_view.security.JwtTokenProvider;
+import com.ctrls.auto_enter_view.util.KeyGenerator;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
@@ -65,6 +66,9 @@ class CommonUserServiceTest {
 
   @Mock
   private BlacklistTokenService blacklistTokenService;
+
+  @Mock
+  private KeyGenerator keyGenerator;
 
   @InjectMocks
   private CommonUserService commonUserService;
@@ -329,25 +333,28 @@ class CommonUserServiceTest {
     String companyName = "TestCompany";
     String password = "password123#";
     String encodedPassword = "encodedPassword";
-    String generatedToken = "generatedToken";
+    String mockedCompanyKey = "companyKey";
+
+    when(keyGenerator.generateKey()).thenReturn(mockedCompanyKey);
+    String companyKey = keyGenerator.generateKey();
 
     CompanyEntity company = CompanyEntity.builder()
         .email(email)
         .companyName(companyName)
         .password(encodedPassword)
         .role(UserRole.ROLE_COMPANY)
+        .companyKey(companyKey)
         .build();
 
     when(companyRepository.findByEmail(email)).thenReturn(Optional.of(company));
     when(passwordEncoder.matches(password, encodedPassword)).thenReturn(true);
-    when(jwtTokenProvider.generateToken(email, UserRole.ROLE_COMPANY)).thenReturn(generatedToken);
 
     // when
     SignInDto.Response response = commonUserService.loginUser(email, password);
 
     // then
     assertEquals(email, response.getEmail());
-    assertEquals(company.getCompanyKey(), response.getKey());
+    assertEquals(companyKey, response.getKey());
     assertEquals(companyName, response.getName());
     assertEquals(UserRole.ROLE_COMPANY, response.getRole());
   }
@@ -360,25 +367,29 @@ class CommonUserServiceTest {
     String name = "TestCandidate";
     String password = "password123#";
     String encodedPassword = "encodedPassword";
-    String generatedToken = "generatedToken";
+    String mockedCandidateKey = "candidateKey";
+
+    // KeyGenerator mock 설정
+    when(keyGenerator.generateKey()).thenReturn(mockedCandidateKey);
+    String candidateKey = keyGenerator.generateKey();
 
     CandidateEntity candidate = CandidateEntity.builder()
         .email(email)
         .name(name)
         .password(encodedPassword)
         .role(ROLE_CANDIDATE)
+        .candidateKey(candidateKey)
         .build();
 
     when(candidateRepository.findByEmail(email)).thenReturn(Optional.of(candidate));
     when(passwordEncoder.matches(password, encodedPassword)).thenReturn(true);
-    when(jwtTokenProvider.generateToken(email, ROLE_CANDIDATE)).thenReturn(generatedToken);
 
     // when
     SignInDto.Response response = commonUserService.loginUser(email, password);
 
     // then
     assertEquals(email, response.getEmail());
-    assertEquals(candidate.getCandidateKey(), response.getKey());
+    assertEquals(candidateKey, response.getKey());
     assertEquals(name, response.getName());
     assertEquals(ROLE_CANDIDATE, response.getRole());
   }

--- a/src/test/java/com/ctrls/auto_enter_view/service/JobPostingImageServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/JobPostingImageServiceTest.java
@@ -1,0 +1,106 @@
+package com.ctrls.auto_enter_view.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.ctrls.auto_enter_view.component.S3ImageUpload;
+import com.ctrls.auto_enter_view.dto.jobPosting.JobPostingDto;
+import com.ctrls.auto_enter_view.entity.JobPostingImageEntity;
+import com.ctrls.auto_enter_view.repository.JobPostingImageRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+class JobPostingImageServiceTest {
+
+  @Mock
+  private JobPostingImageRepository jobPostingImageRepository;
+
+  @Mock
+  private S3ImageUpload s3ImageUpload;
+
+  @InjectMocks
+  private JobPostingImageService jobPostingImageService;
+
+  @Test
+  @DisplayName("이미지 파일 업로드 테스트")
+  void uploadImage() {
+    // given
+    MultipartFile image = mock(MultipartFile.class);
+    String jobPostingKey = "jobPostingKey";
+    String companyImageUrl = "https://example.com/image.jpg";
+
+    when(jobPostingImageRepository.findByJobPostingKey(jobPostingKey))
+        .thenReturn(Optional.empty());
+    when(s3ImageUpload.uploadImage(image, "job-posting-images")).thenReturn(companyImageUrl);
+
+    ArgumentCaptor<JobPostingImageEntity> entityCaptor = ArgumentCaptor.forClass(JobPostingImageEntity.class);
+
+    // when
+    JobPostingDto.Response response = jobPostingImageService.uploadImage(image, jobPostingKey);
+
+    // then
+    assertNotNull(response);
+    assertEquals(jobPostingKey, response.getJobPostingKey());
+    assertEquals(companyImageUrl, response.getJobPostingImageUrl());
+
+    verify(jobPostingImageRepository, times(1)).save(entityCaptor.capture());
+    JobPostingImageEntity savedEntity = entityCaptor.getValue();
+    assertEquals(jobPostingKey, savedEntity.getJobPostingKey());
+    assertEquals(companyImageUrl, savedEntity.getCompanyImageUrl());
+  }
+
+  @Test
+  @DisplayName("채용공고 이미지 조회 테스트")
+  void getJobPostingImage() {
+    // given
+    String jobPostingKey = "jobPostingKey";
+    String companyImageUrl = "https://example.com/image.jpg";
+
+    JobPostingImageEntity imageEntity = JobPostingImageEntity.builder()
+        .jobPostingKey(jobPostingKey)
+        .companyImageUrl(companyImageUrl)
+        .build();
+
+    when(jobPostingImageRepository.findByJobPostingKey(jobPostingKey))
+        .thenReturn(Optional.of(imageEntity));
+
+    // when
+    JobPostingDto.Response response = jobPostingImageService.getJobPostingImage(jobPostingKey);
+
+    // then
+    assertNotNull(response);
+    assertEquals(jobPostingKey, response.getJobPostingKey());
+    assertEquals(companyImageUrl, response.getJobPostingImageUrl());
+  }
+
+  @Test
+  @DisplayName("이미지 파일 삭제 테스트")
+  void deleteImage() {
+    // given
+    String jobPostingKey = "jobPostingKey";
+    String companyImageUrl = "https://example.com/image.jpg";
+
+    JobPostingImageEntity imageEntity = JobPostingImageEntity.builder()
+        .jobPostingKey(jobPostingKey)
+        .companyImageUrl(companyImageUrl)
+        .build();
+
+    when(jobPostingImageRepository.findByJobPostingKey(jobPostingKey))
+        .thenReturn(Optional.of(imageEntity));
+
+    // when
+    jobPostingImageService.deleteImage(jobPostingKey);
+
+    // then
+    verify(s3ImageUpload, times(1)).deleteImage(companyImageUrl);
+    verify(jobPostingImageRepository, times(1)).delete(imageEntity);
+  }
+}

--- a/src/test/java/com/ctrls/auto_enter_view/service/JobPostingStepServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/JobPostingStepServiceTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.ctrls.auto_enter_view.dto.candidateList.CandidateTechStackInterviewInfoDto;
@@ -20,6 +21,7 @@ import com.ctrls.auto_enter_view.entity.JobPostingEntity;
 import com.ctrls.auto_enter_view.entity.JobPostingStepEntity;
 import com.ctrls.auto_enter_view.entity.ResumeEntity;
 import com.ctrls.auto_enter_view.entity.ResumeTechStackEntity;
+import com.ctrls.auto_enter_view.enums.ErrorCode;
 import com.ctrls.auto_enter_view.exception.CustomException;
 import com.ctrls.auto_enter_view.repository.CandidateListRepository;
 import com.ctrls.auto_enter_view.repository.CompanyRepository;
@@ -29,8 +31,10 @@ import com.ctrls.auto_enter_view.repository.JobPostingRepository;
 import com.ctrls.auto_enter_view.repository.JobPostingStepRepository;
 import com.ctrls.auto_enter_view.repository.ResumeRepository;
 import com.ctrls.auto_enter_view.repository.ResumeTechStackRepository;
+import com.ctrls.auto_enter_view.util.KeyGenerator;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -68,6 +72,9 @@ class JobPostingStepServiceTest {
 
   @Mock
   private InterviewScheduleParticipantsRepository interviewScheduleParticipantsRepository;
+
+  @Mock
+  private KeyGenerator keyGenerator;
 
   @InjectMocks
   private JobPostingStepService jobPostingStepService;
@@ -254,5 +261,280 @@ class JobPostingStepServiceTest {
     });
 
     assertEquals(RESUME_NOT_FOUND, thrownException.getErrorCode());
+  }
+
+  @Test
+  @DisplayName("채용 단계 올리기 테스트 - 성공")
+  void editStepIdSuccessTest() {
+    // given
+    long currentStepId = 1L;
+    List<String> candidateKeys = List.of("candidateKey1", "candidateKey2");
+    String jobPostingKey = "jobPostingKey";
+    String companyEmail = "company@example.com";
+    String mockedCompanyKey = "companyKey";
+
+    // KeyGenerator mock 설정
+    when(keyGenerator.generateKey()).thenReturn(mockedCompanyKey);
+    String companyKey = keyGenerator.generateKey();
+
+    CompanyEntity companyEntity = CompanyEntity.builder()
+        .companyKey(companyKey)
+        .email(companyEmail)
+        .build();
+    when(companyRepository.findByEmail(companyEmail)).thenReturn(Optional.of(companyEntity));
+
+    JobPostingEntity jobPostingEntity = JobPostingEntity.builder()
+        .companyKey(companyKey)
+        .jobPostingKey(jobPostingKey)
+        .build();
+    when(jobPostingRepository.findByJobPostingKey(jobPostingKey)).thenReturn(Optional.of(jobPostingEntity));
+
+    Long nextStepId = currentStepId + 1;
+    JobPostingStepEntity nextStepEntity = JobPostingStepEntity.builder()
+        .id(nextStepId)
+        .jobPostingKey(jobPostingKey)
+        .build();
+    when(jobPostingStepRepository.findByJobPostingKeyAndId(jobPostingKey, nextStepId)).thenReturn(Optional.of(nextStepEntity));
+
+    List<CandidateListEntity> candidateListEntities = new ArrayList<>();
+    for (String candidateKey : candidateKeys) {
+      CandidateListEntity candidateListEntity = CandidateListEntity.builder()
+          .candidateKey(candidateKey)
+          .jobPostingKey(jobPostingKey)
+          .build();
+      candidateListEntities.add(candidateListEntity);
+    }
+    when(candidateListRepository.findAllByCandidateKeyInAndJobPostingKey(candidateKeys, jobPostingKey)).thenReturn(candidateListEntities);
+
+    UserDetails userDetails = org.springframework.security.core.userdetails.User.builder()
+        .username(companyEmail)
+        .password("")
+        .roles("COMPANY")
+        .build();
+
+    // when
+    jobPostingStepService.editStepId(currentStepId, candidateKeys, jobPostingKey, userDetails);
+
+    // then
+    for (CandidateListEntity candidate : candidateListEntities) {
+      assertEquals(nextStepId, candidate.getJobPostingStepId());
+    }
+  }
+
+  @Test
+  @DisplayName("채용 단계 올리기 테스트 - 실패 : 회사를 찾을 수 없는 경우")
+  void editStepIdCompanyNotFoundTest() {
+    // given
+    long currentStepId = 1L;
+    List<String> candidateKeys = List.of("candidateKey1", "candidateKey2");
+    String jobPostingKey = "jobPostingKey";
+    String companyEmail = "nonexistent@example.com";
+
+    UserDetails userDetails = org.springframework.security.core.userdetails.User.builder()
+        .username(companyEmail)
+        .password("")
+        .roles("COMPANY")
+        .build();
+
+    when(companyRepository.findByEmail(companyEmail)).thenReturn(Optional.empty());
+
+    // when
+    CustomException exception = assertThrows(CustomException.class, () ->
+        jobPostingStepService.editStepId(currentStepId, candidateKeys, jobPostingKey, userDetails)
+    );
+
+    // then
+    assertEquals(ErrorCode.COMPANY_NOT_FOUND, exception.getErrorCode());
+    verify(companyRepository).findByEmail(companyEmail);
+  }
+
+  @Test
+  @DisplayName("채용 단계 올리기 테스트 - 실패 : 채용 공고를 찾을 수 없는 경우")
+  void editStepIdJobPostingNotFoundTest() {
+    // given
+    long currentStepId = 1L;
+    List<String> candidateKeys = List.of("candidateKey1", "candidateKey2");
+    String jobPostingKey = "nonexistentJobPosting";
+    String companyEmail = "company@example.com";
+    String mockedCompanyKey = "companyKey";
+
+    // KeyGenerator mock 설정
+    when(keyGenerator.generateKey()).thenReturn(mockedCompanyKey);
+    String companyKey = keyGenerator.generateKey();
+
+    CompanyEntity companyEntity = CompanyEntity.builder()
+        .companyKey(companyKey)
+        .email(companyEmail)
+        .build();
+    when(companyRepository.findByEmail(companyEmail)).thenReturn(Optional.of(companyEntity));
+
+    when(jobPostingRepository.findByJobPostingKey(jobPostingKey)).thenReturn(Optional.empty());
+
+    UserDetails userDetails = org.springframework.security.core.userdetails.User.builder()
+        .username(companyEmail)
+        .password("")
+        .roles("COMPANY")
+        .build();
+
+    // when
+    CustomException exception = assertThrows(CustomException.class, () ->
+        jobPostingStepService.editStepId(currentStepId, candidateKeys, jobPostingKey, userDetails)
+    );
+
+    // then
+    assertEquals(ErrorCode.JOB_POSTING_NOT_FOUND, exception.getErrorCode());
+    verify(companyRepository).findByEmail(companyEmail);
+    verify(jobPostingRepository).findByJobPostingKey(jobPostingKey);
+  }
+
+  @Test
+  @DisplayName("채용 단계 올리기 테스트 - 실패 : 권한이 없는 경우")
+  void editStepIdNoAuthorityTest() {
+    // given
+    long currentStepId = 1L;
+    List<String> candidateKeys = List.of("candidateKey1", "candidateKey2");
+    String jobPostingKey = "jobPostingKey";
+    String companyEmail = "company@example.com";
+    String mockedCompanyKey = "companyKey";
+    String differentCompanyKey = "differentCompanyKey";
+
+    // KeyGenerator mock 설정
+    when(keyGenerator.generateKey()).thenReturn(mockedCompanyKey);
+    String companyKey = keyGenerator.generateKey();
+
+    CompanyEntity companyEntity = CompanyEntity.builder()
+        .companyKey(companyKey)
+        .email(companyEmail)
+        .build();
+    when(companyRepository.findByEmail(companyEmail)).thenReturn(Optional.of(companyEntity));
+
+    JobPostingEntity jobPostingEntity = JobPostingEntity.builder()
+        .companyKey(differentCompanyKey)  // 다른 회사의 키
+        .jobPostingKey(jobPostingKey)
+        .build();
+    when(jobPostingRepository.findByJobPostingKey(jobPostingKey)).thenReturn(Optional.of(jobPostingEntity));
+
+    UserDetails userDetails = org.springframework.security.core.userdetails.User.builder()
+        .username(companyEmail)
+        .password("")
+        .roles("COMPANY")
+        .build();
+
+    // when
+    CustomException exception = assertThrows(CustomException.class, () ->
+        jobPostingStepService.editStepId(currentStepId, candidateKeys, jobPostingKey, userDetails)
+    );
+
+    // then
+    assertEquals(ErrorCode.NO_AUTHORITY, exception.getErrorCode());
+    verify(companyRepository).findByEmail(companyEmail);
+    verify(jobPostingRepository).findByJobPostingKey(jobPostingKey);
+  }
+
+  @Test
+  @DisplayName("채용 단계 올리기 테스트 - 실패 : 다음 단계가 없는 경우")
+  void editStepIdNextStepNotFoundTest() {
+    // given
+    long currentStepId = 1L;
+    List<String> candidateKeys = List.of("candidateKey1", "candidateKey2");
+    String jobPostingKey = "jobPostingKey";
+    String companyEmail = "company@example.com";
+    String mockedCompanyKey = "companyKey";
+
+    // KeyGenerator mock 설정
+    when(keyGenerator.generateKey()).thenReturn(mockedCompanyKey);
+    String companyKey = keyGenerator.generateKey();
+
+    CompanyEntity companyEntity = CompanyEntity.builder()
+        .companyKey(companyKey)
+        .email(companyEmail)
+        .build();
+    when(companyRepository.findByEmail(companyEmail)).thenReturn(Optional.of(companyEntity));
+
+    JobPostingEntity jobPostingEntity = JobPostingEntity.builder()
+        .companyKey(companyKey)
+        .jobPostingKey(jobPostingKey)
+        .build();
+    when(jobPostingRepository.findByJobPostingKey(jobPostingKey)).thenReturn(Optional.of(jobPostingEntity));
+
+    Long nextStepId = currentStepId + 1;
+    when(jobPostingStepRepository.findByJobPostingKeyAndId(jobPostingKey, nextStepId)).thenReturn(Optional.empty());
+
+    UserDetails userDetails = org.springframework.security.core.userdetails.User.builder()
+        .username(companyEmail)
+        .password("")
+        .roles("COMPANY")
+        .build();
+
+    // when
+    CustomException exception = assertThrows(CustomException.class, () ->
+        jobPostingStepService.editStepId(currentStepId, candidateKeys, jobPostingKey, userDetails)
+    );
+
+    // then
+    assertEquals(ErrorCode.NEXT_STEP_NOT_FOUND, exception.getErrorCode());
+    verify(companyRepository).findByEmail(companyEmail);
+    verify(jobPostingRepository).findByJobPostingKey(jobPostingKey);
+    verify(jobPostingStepRepository).findByJobPostingKeyAndId(jobPostingKey, nextStepId);
+  }
+
+  @Test
+  @DisplayName("채용 단계 올리기 테스트 - 실패 : 지원자를 찾을 수 없는 경우")
+  void editStepIdCandidateNotFoundTest() {
+    // given
+    long currentStepId = 1L;
+    List<String> candidateKeys = List.of("candidateKey1", "candidateKey2");
+    String jobPostingKey = "jobPostingKey";
+    String companyEmail = "company@example.com";
+    String mockedCompanyKey = "companyKey";
+
+    // KeyGenerator mock 설정
+    when(keyGenerator.generateKey()).thenReturn(mockedCompanyKey);
+    String companyKey = keyGenerator.generateKey();
+
+    CompanyEntity companyEntity = CompanyEntity.builder()
+        .companyKey(companyKey)
+        .email(companyEmail)
+        .build();
+    when(companyRepository.findByEmail(companyEmail)).thenReturn(Optional.of(companyEntity));
+
+    JobPostingEntity jobPostingEntity = JobPostingEntity.builder()
+        .companyKey(companyKey)
+        .jobPostingKey(jobPostingKey)
+        .build();
+    when(jobPostingRepository.findByJobPostingKey(jobPostingKey)).thenReturn(Optional.of(jobPostingEntity));
+
+    Long nextStepId = currentStepId + 1;
+    JobPostingStepEntity nextStepEntity = JobPostingStepEntity.builder()
+        .id(nextStepId)
+        .jobPostingKey(jobPostingKey)
+        .build();
+    when(jobPostingStepRepository.findByJobPostingKeyAndId(jobPostingKey, nextStepId)).thenReturn(Optional.of(nextStepEntity));
+
+    // 지원자를 찾을 수 없는 상황 설정
+    List<CandidateListEntity> candidateListEntities = List.of(CandidateListEntity.builder()
+        .candidateKey("candidateKey1")
+        .jobPostingKey(jobPostingKey)
+        .build());
+    when(candidateListRepository.findAllByCandidateKeyInAndJobPostingKey(candidateKeys, jobPostingKey))
+        .thenReturn(candidateListEntities);
+
+    UserDetails userDetails = org.springframework.security.core.userdetails.User.builder()
+        .username(companyEmail)
+        .password("")
+        .roles("COMPANY")
+        .build();
+
+    // when
+    CustomException exception = assertThrows(CustomException.class, () ->
+        jobPostingStepService.editStepId(currentStepId, candidateKeys, jobPostingKey, userDetails)
+    );
+
+    // then
+    assertEquals(ErrorCode.CANDIDATE_NOT_FOUND, exception.getErrorCode());
+    verify(companyRepository).findByEmail(companyEmail);
+    verify(jobPostingRepository).findByJobPostingKey(jobPostingKey);
+    verify(jobPostingStepRepository).findByJobPostingKeyAndId(jobPostingKey, nextStepId);
+    verify(candidateListRepository).findAllByCandidateKeyInAndJobPostingKey(candidateKeys, jobPostingKey);
   }
 }

--- a/src/test/java/com/ctrls/auto_enter_view/service/ResumeImageServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/ResumeImageServiceTest.java
@@ -1,0 +1,142 @@
+package com.ctrls.auto_enter_view.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.ctrls.auto_enter_view.component.S3ImageUpload;
+import com.ctrls.auto_enter_view.dto.resume.ResumeDto;
+import com.ctrls.auto_enter_view.entity.ResumeEntity;
+import com.ctrls.auto_enter_view.entity.ResumeImageEntity;
+import com.ctrls.auto_enter_view.repository.ResumeImageRepository;
+import com.ctrls.auto_enter_view.repository.ResumeRepository;
+import com.ctrls.auto_enter_view.util.KeyGenerator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Optional;
+
+class ResumeImageServiceTest {
+
+  @Mock
+  private KeyGenerator keyGenerator;
+
+  @Mock
+  private ResumeImageRepository resumeImageRepository;
+
+  @Mock
+  private S3ImageUpload s3ImageUpload;
+
+  @Mock
+  private ResumeRepository resumeRepository;
+
+  @InjectMocks
+  private ResumeImageService resumeImageService;
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+  }
+
+  @Test
+  @DisplayName("새 이미지 업로드 성공 테스트")
+  void uploadImage_NewImage() {
+    // Given
+    MultipartFile mockFile = mock(MultipartFile.class);
+    String resumeKey = "testResumeKey";
+    String imageUrl = "http://test-image-url.com";
+
+    when(keyGenerator.generateKey()).thenReturn(resumeKey);
+    when(resumeImageRepository.findByResumeKey(resumeKey)).thenReturn(Optional.empty());
+    when(s3ImageUpload.uploadImage(mockFile, "resume-images")).thenReturn(imageUrl);
+
+    // When
+    ResumeDto.Response response = resumeImageService.uploadImage(mockFile, resumeKey);
+
+    // Then
+    assertEquals(resumeKey, response.getResumeKey());
+    assertEquals(imageUrl, response.getResumeImageUrl());
+    verify(resumeImageRepository).save(argThat(entity ->
+        entity.getResumeKey().equals(resumeKey) &&
+            entity.getResumeImageUrl().equals(imageUrl)));
+  }
+
+  @Test
+  @DisplayName("기존 이미지 수정 성공 테스트")
+  void uploadImage_ExistingImage() {
+    // Given
+    MultipartFile mockFile = mock(MultipartFile.class);
+    String resumeKey = "testResumeKey";
+    String oldImageUrl = "http://old-image-url.com";
+    String newImageUrl = "http://new-image-url.com";
+
+    ResumeImageEntity existingImage = ResumeImageEntity.builder()
+        .resumeKey(resumeKey)
+        .resumeImageUrl(oldImageUrl)
+        .build();
+
+    when(keyGenerator.generateKey()).thenReturn(resumeKey);
+    when(resumeImageRepository.findByResumeKey(resumeKey)).thenReturn(Optional.of(existingImage));
+    when(s3ImageUpload.uploadImage(mockFile, "resume-images")).thenReturn(newImageUrl);
+
+    // When
+    ResumeDto.Response response = resumeImageService.uploadImage(mockFile, resumeKey);
+
+    // Then
+    assertEquals(resumeKey, response.getResumeKey());
+    assertEquals(newImageUrl, response.getResumeImageUrl());
+    verify(s3ImageUpload).deleteImage(oldImageUrl);
+    verify(resumeImageRepository).save(existingImage);
+  }
+
+  @Test
+  @DisplayName("기존 이미지 조회 성공 테스트")
+  void getExistingResumeImage_Exists() {
+    // Given
+    String resumeKey = "testResumeKey";
+    String imageUrl = "http://test-image-url.com";
+    ResumeImageEntity resumeImage = ResumeImageEntity.builder()
+        .resumeKey(resumeKey)
+        .resumeImageUrl(imageUrl)
+        .build();
+
+    when(keyGenerator.generateKey()).thenReturn(resumeKey);
+    when(resumeImageRepository.findByResumeKey(resumeKey)).thenReturn(Optional.of(resumeImage));
+
+    // When
+    ResumeDto.Response response = resumeImageService.getExistingResumeImage(resumeKey);
+
+    // Then
+    assertEquals(resumeKey, response.getResumeKey());
+    assertEquals(imageUrl, response.getResumeImageUrl());
+  }
+
+  @Test
+  @DisplayName("이미지 삭제 성공 테스트")
+  void deleteImage_Exists() {
+    // Given
+    String candidateKey = "testCandidateKey";
+    String resumeKey = "testResumeKey";
+    String imageUrl = "http://test-image-url.com";
+
+    ResumeEntity resume = ResumeEntity.builder().resumeKey(resumeKey).build();
+    ResumeImageEntity resumeImage = ResumeImageEntity.builder()
+        .resumeKey(resumeKey)
+        .resumeImageUrl(imageUrl)
+        .build();
+
+    when(resumeRepository.findByCandidateKey(candidateKey)).thenReturn(Optional.of(resume));
+    when(resumeImageRepository.findByResumeKey(resumeKey)).thenReturn(Optional.of(resumeImage));
+
+    // When
+    resumeImageService.deleteImage(candidateKey);
+
+    // Then
+    verify(s3ImageUpload).deleteImage(imageUrl);
+    verify(resumeImageRepository).delete(resumeImage);
+  }
+}


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 현재 메인에 머지되어있는 상태가 디벨롭브랜치에 없어서 엉망인 상태

**TO-BE**
- keyGenerator class를 util 에서 component로 이동
- BlackListTokenServiceTest에 실패 케이스 추가
- 로그인 테스트에서 keyGenerator 사용 
- 사용하지 않는 필드 삭제 (jwt token)
- JobPostingStepService 테스트 코드 추가
- ResumeImageService 테스트 코드 추가
- JobPostingImageService 테스트 코드 추가

### 테스트

- [ ] 테스트 코드
- [ ] API 테스트 