### PR TITLE
채용 공고 단계 수정 로직에 stepId 체크 로직 추가

### DIFF
--- a/src/main/java/com/ctrls/auto_enter_view/enums/ErrorCode.java
+++ b/src/main/java/com/ctrls/auto_enter_view/enums/ErrorCode.java
@@ -50,7 +50,8 @@ public enum ErrorCode {
   SCHEDULE_FAILED(500, "스케줄링에 실패하였습니다."),
   UNSCHEDULE_FAILED(500, "스케줄링 취소에 실패하였습니다."),
   FAILED_MAIL_SCHEDULING(500, "메일 예약 등록을 실패했습니다."),
-  FAILED_MAIL_UNSCHEDULING(500, "메일 예약 취소를 실패했습니다.");
+  FAILED_MAIL_UNSCHEDULING(500, "메일 예약 취소를 실패했습니다."),
+  INVALID_CURRENT_STEP_ID(400, "잘못된 채용 공고 단계 입니다.");
 
   private final int status;
   private final String message;

--- a/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
@@ -373,6 +373,21 @@ public class JobPostingStepService {
       throw new CustomException(ErrorCode.NO_AUTHORITY);
     }
 
+    // 지원자 정보 조회
+    List<CandidateListEntity> candidateListEntities = candidateListRepository
+        .findAllByCandidateKeyInAndJobPostingKey(candidateKeys, jobPostingKey);
+
+    if (candidateListEntities.size() != candidateKeys.size()) {
+      throw new CustomException(ErrorCode.CANDIDATE_NOT_FOUND);
+    }
+
+    // 지원자의 현재 단계 ID 확인
+    for (CandidateListEntity candidate : candidateListEntities) {
+      if (!candidate.getJobPostingStepId().equals(currentStepId)) {
+        throw new CustomException(ErrorCode.INVALID_CURRENT_STEP_ID);
+      }
+    }
+
     // 다음 단계 ID 계산
     Long nextStepId = currentStepId + 1;
 
@@ -382,14 +397,6 @@ public class JobPostingStepService {
 
     if (nextStepOptional.isEmpty()) {
       throw new CustomException(ErrorCode.NEXT_STEP_NOT_FOUND);
-    }
-
-    // 지원자 정보 조회
-    List<CandidateListEntity> candidateListEntities = candidateListRepository
-        .findAllByCandidateKeyInAndJobPostingKey(candidateKeys, jobPostingKey);
-
-    if (candidateListEntities.size() != candidateKeys.size()) {
-      throw new CustomException(ErrorCode.CANDIDATE_NOT_FOUND);
     }
 
     // 지원자의 단계 ID 업데이트

--- a/src/test/java/com/ctrls/auto_enter_view/service/ResumeServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/ResumeServiceTest.java
@@ -34,7 +34,6 @@ import com.ctrls.auto_enter_view.repository.JobPostingRepository;
 import com.ctrls.auto_enter_view.repository.ResumeCareerRepository;
 import com.ctrls.auto_enter_view.repository.ResumeCertificateRepository;
 import com.ctrls.auto_enter_view.repository.ResumeExperienceRepository;
-import com.ctrls.auto_enter_view.repository.ResumeImageRepository;
 import com.ctrls.auto_enter_view.repository.ResumeRepository;
 import com.ctrls.auto_enter_view.repository.ResumeTechStackRepository;
 import java.time.LocalDate;

--- a/src/test/java/com/ctrls/auto_enter_view/service/ResumeServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/ResumeServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.ctrls.auto_enter_view.component.KeyGenerator;
 import com.ctrls.auto_enter_view.dto.resume.CareerDto;
 import com.ctrls.auto_enter_view.dto.resume.CertificateDto;
 import com.ctrls.auto_enter_view.dto.resume.ExperienceDto;
@@ -36,7 +37,6 @@ import com.ctrls.auto_enter_view.repository.ResumeExperienceRepository;
 import com.ctrls.auto_enter_view.repository.ResumeImageRepository;
 import com.ctrls.auto_enter_view.repository.ResumeRepository;
 import com.ctrls.auto_enter_view.repository.ResumeTechStackRepository;
-import com.ctrls.auto_enter_view.component.KeyGenerator;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -78,9 +78,6 @@ class ResumeServiceTest {
 
   @Mock
   private ResumeExperienceRepository resumeExperienceRepository;
-
-  @Mock
-  private ResumeImageRepository resumeImageRepository;
 
   @Mock
   private ResumeRepository resumeRepository;


### PR DESCRIPTION
### 변경사항

**AS-IS**
- 채용 단계 올리기 로직에서 현재 단계 StepId(currentStepId)의 유효성 검사 없음
- 지원자의 현재 채용 공고 단계와 상관없이 단계 이동이 가능함

**TO-BE**
- 입력받은 currentStepId와 지원자의 현재 채용 공고 단계 ID를 비교하여 일치하는지 확인하는 로직 추가
- 지원자의 현재 채용 공고 단계가 currentStepId와 일치하지 않는 경우 CustomException 발생
- 지원자의 현재 채용 공고 단계와 currentStepId가 일치해야만 단계 이동 가능

### 테스트
- [x] 테스트 코드
- editStepIdSuccessTest : 채용 공고 단계 올리기 성공 테스트
- editStepIdInvalidCurrentStepIdTest : 지원자의 현재 채용 공고 단계가 일치하지 않는 경우 실패 테스트

- [x] API 테스트 