### PR TITLE
채용 공고 전체 조회 페이징 처리 개선

### DIFF
--- a/src/main/java/com/ctrls/auto_enter_view/repository/JobPostingRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/JobPostingRepository.java
@@ -8,7 +8,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository

--- a/src/main/java/com/ctrls/auto_enter_view/repository/JobPostingRepository.java
+++ b/src/main/java/com/ctrls/auto_enter_view/repository/JobPostingRepository.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -18,12 +20,14 @@ public interface JobPostingRepository extends JpaRepository<JobPostingEntity, St
 
   void deleteByJobPostingKey(String jobPostingKey);
 
-  boolean existsByJobPostingKey(String jobPostingKey);
-
-  Page<JobPostingEntity> findByEndDateGreaterThanEqual(LocalDate currentDate, Pageable pageable);
-
   boolean existsByJobPostingKeyAndEndDateGreaterThanEqual(String jobPostingKey,
       LocalDate currentDate);
 
-  JobPostingEntity findByCompanyKey(String companyKey);
+  @Query("SELECT j FROM JobPostingEntity j "
+      + "LEFT JOIN CompanyEntity c "
+      + "ON j.companyKey = c.companyKey "
+      + "WHERE c.companyKey IS NOT NULL "
+      + "AND j.endDate >= :currentDate")
+  Page<JobPostingEntity> findByEndDateGreaterThanEqual(LocalDate currentDate, Pageable pageable);
+
 }

--- a/src/test/java/com/ctrls/auto_enter_view/service/JobPostingServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/JobPostingServiceTest.java
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.ctrls.auto_enter_view.component.KeyGenerator;
 import com.ctrls.auto_enter_view.component.MailComponent;
 import com.ctrls.auto_enter_view.dto.common.JobPostingDetailDto;
 import com.ctrls.auto_enter_view.dto.common.MainJobPostingDto;
@@ -51,7 +52,6 @@ import com.ctrls.auto_enter_view.repository.JobPostingImageRepository;
 import com.ctrls.auto_enter_view.repository.JobPostingRepository;
 import com.ctrls.auto_enter_view.repository.JobPostingStepRepository;
 import com.ctrls.auto_enter_view.repository.JobPostingTechStackRepository;
-import com.ctrls.auto_enter_view.component.KeyGenerator;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
@@ -712,45 +712,24 @@ class JobPostingServiceTest {
   }
 
   @Test
-  @DisplayName("Main 화면 채용 공고 조회 - 탈퇴한 회사 처리 테스트")
-  void getAllJobPosting_withWithdrawnCompany() {
+  @DisplayName("Main 화면 채용 공고 조회 - 빈 결과")
+  void getAllJobPosting_emptyResult() {
     // given
     int page = 1;
     int size = 10;
     Pageable pageable = PageRequest.of(page - 1, size);
     LocalDate currentDate = LocalDate.now();
 
-    JobPostingEntity jobPosting = JobPostingEntity.builder()
-        .jobPostingKey("jobPostingKey")
-        .companyKey("withdrawnCompanyKey")
-        .title("테스트 채용 공고")
-        .jobCategory(JobCategory.BACKEND)
-        .career(3)
-        .workLocation("서울")
-        .education(Education.BACHELOR)
-        .employmentType("정규직")
-        .salary(50000000L)
-        .workTime("유연근무제")
-        .startDate(LocalDate.now())
-        .endDate(LocalDate.now().plusDays(30))
-        .passingNumber(5)
-        .jobPostingContent("상세 내용")
-        .build();
+    Page<JobPostingEntity> emptyPage = new PageImpl<>(Collections.emptyList(), pageable, 0);
 
-    List<JobPostingEntity> jobPostings = Collections.singletonList(jobPosting);
-    Page<JobPostingEntity> jobPostingPage = new PageImpl<>(jobPostings, pageable, jobPostings.size());
-
-//    List<TechStack> techStacks = Arrays.asList(TechStack.HTML5, TechStack.PYTHON);
-
-    when(jobPostingRepository.findByEndDateGreaterThanEqual(currentDate, pageable)).thenReturn(jobPostingPage);
-    when(companyRepository.findByCompanyKey("withdrawnCompanyKey")).thenReturn(Optional.empty());
+    when(jobPostingRepository.findByEndDateGreaterThanEqual(currentDate, pageable)).thenReturn(emptyPage);
 
     // when
     MainJobPostingDto.Response response = jobPostingService.getAllJobPosting(page, size);
 
     // then
     assertNotNull(response);
-    assertEquals(0, response.getJobPostingsList().size());
+    assertTrue(response.getJobPostingsList().isEmpty());
     assertEquals(0, response.getTotalPages());
     assertEquals(0, response.getTotalElements());
   }


### PR DESCRIPTION
### 변경사항

**AS-IS**
- totalElements가 page 내 elements로 잘못 계산되고 있음
- totalPages도 증가하지 않고 있음

**TO-BE**
- totalElements와 totalPages 계산 로직 수정
- totalElements는 마감일이 지나고, 탈퇴한 회사를 제외한 채용 공고 전체 개수를 나타냄
- totalPages는 totalElements에서 size로 나눈 후 올림 한 값을 나타냄 = 전체 페이지 
- Page 객체의 정보를 직접 사용하여 정확한 페이징 정보 제공
- 불필요한 필터링 로직 제거로 성능 개선
- 채용 공고 전체 조회 테스트 케이스 수정
- 불필요한 회사 탈퇴 관련 테스트 제거
- 빈 결과에 대한 새로운 테스트 케이스 추가

### 테스트
- [x] 테스트 코드
- [x] API 테스트 