### PR TITLE
회원 탈퇴 테스트 코드 작성 (지원자,회사) & withdraw 로직 변경

### DIFF
--- a/src/main/java/com/ctrls/auto_enter_view/service/CommonUserService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/CommonUserService.java
@@ -279,7 +279,7 @@ public class CommonUserService {
    * 회원 탈퇴
    *
    * @param userDetails 로그인 된 사용자 정보
-   * @param key CompanyKey 또는 CandidateKey
+   * @param key         CompanyKey 또는 CandidateKey
    * @throws CustomException USER_NOT_FOUND : 사용자를 찾을 수 없는 경우
    * @throws CustomException KEY_NOT_MATCH : 키가 일치하지 않는 경우
    */
@@ -292,7 +292,7 @@ public class CommonUserService {
 
       if (role.equals(ROLE_CANDIDATE.name())) {
 
-        CandidateEntity candidateEntity = candidateRepository.findByCandidateKey(key)
+        CandidateEntity candidateEntity = candidateRepository.findByEmail(userDetails.getUsername())
             .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         // 응시자 정보의 응시자키와 URL 응시자키 일치 확인
@@ -307,7 +307,7 @@ public class CommonUserService {
         candidateRepository.delete(candidateEntity);
       } else {
 
-        CompanyEntity companyEntity = companyRepository.findByCompanyKey(key)
+        CompanyEntity companyEntity = companyRepository.findByEmail(userDetails.getUsername())
             .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
 
         // 회사 정보의 회사키와 URL 회사키 일치 확인

--- a/src/test/java/com/ctrls/auto_enter_view/service/CommonUserServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/CommonUserServiceTest.java
@@ -516,7 +516,7 @@ class CommonUserServiceTest {
 
   @Test
   @DisplayName("회원 탈퇴 실패 테스트 (지원자) -> KEY_NOT_MATCH")
-  void candidateWithdrawFailTest() {
+  void candidateWithdrawFailTestKeyNotMatch() {
     //given
     String email = "email";
     String password = "password";
@@ -539,6 +539,30 @@ class CommonUserServiceTest {
     //then
     verify(candidateRepository, times(1)).findByEmail(userDetails.getUsername());
     assertEquals(ErrorCode.KEY_NOT_MATCH, customException.getErrorCode());
+
+  }
+
+  @Test
+  @DisplayName("회원 탈퇴 실패 테스트 (지원자) -> USER_NOT_FOUND")
+  void candidateWithdrawFailTestUserNotFound() {
+    //given
+    String email = "email";
+    String password = "password";
+    String key = "key";
+
+    UserDetails userDetails = User.withUsername(email).password(password)
+        .roles("CANDIDATE").build();
+    
+    when(candidateRepository.findByEmail(userDetails.getUsername())).thenReturn(
+        Optional.empty());
+
+    // when
+    CustomException customException = assertThrows(CustomException.class,
+        () -> commonUserService.withdraw(userDetails, key));
+
+    //then
+    verify(candidateRepository, times(1)).findByEmail(userDetails.getUsername());
+    assertEquals(ErrorCode.USER_NOT_FOUND, customException.getErrorCode());
 
   }
 

--- a/src/test/java/com/ctrls/auto_enter_view/service/CommonUserServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/CommonUserServiceTest.java
@@ -12,6 +12,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -21,11 +22,14 @@ import com.ctrls.auto_enter_view.component.MailComponent;
 import com.ctrls.auto_enter_view.dto.common.SignInDto;
 import com.ctrls.auto_enter_view.entity.CandidateEntity;
 import com.ctrls.auto_enter_view.entity.CompanyEntity;
+import com.ctrls.auto_enter_view.enums.ErrorCode;
 import com.ctrls.auto_enter_view.enums.UserRole;
 import com.ctrls.auto_enter_view.exception.CustomException;
 import com.ctrls.auto_enter_view.repository.CandidateRepository;
+import com.ctrls.auto_enter_view.repository.CompanyInfoRepository;
 import com.ctrls.auto_enter_view.repository.CompanyRepository;
 import com.ctrls.auto_enter_view.component.KeyGenerator;
+import com.ctrls.auto_enter_view.repository.ResumeRepository;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.DisplayName;
@@ -37,10 +41,18 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @ExtendWith(MockitoExtension.class)
 class CommonUserServiceTest {
+
+  @Mock
+  private CompanyInfoRepository companyInfoRepository;
+
+  @Mock
+  private ResumeRepository resumeRepository;
 
   @Mock
   private CompanyRepository companyRepository;
@@ -447,4 +459,87 @@ class CommonUserServiceTest {
     // then
     verify(blacklistTokenService, times(1)).addToBlacklist(token);
   }
+
+  @Test
+  @DisplayName("회원 탈퇴 성공 테스트 (지원자)")
+  void candidateWithdrawTest() {
+    //given
+    String email = "email";
+    String password = "password";
+    String key = "key";
+
+    UserDetails userDetails = User.withUsername(email).password(password)
+        .roles("CANDIDATE").build();
+
+    CandidateEntity candidateEntity = CandidateEntity.builder()
+        .candidateKey(key)
+        .build();
+
+    when(candidateRepository.findByCandidateKey(key)).thenReturn(Optional.of(candidateEntity));
+
+    // when
+    commonUserService.withdraw(userDetails, key);
+
+    //then
+    verify(candidateRepository, times(1)).delete(candidateEntity);
+    verify(resumeRepository, times(1)).deleteByCandidateKey(key);
+
+  }
+
+
+  @Test
+  @DisplayName("회원 탈퇴 성공 테스트 (회사)")
+  void companyWithdrawTest() {
+    //given
+    String email = "email";
+    String password = "password";
+    String key = "key";
+
+    UserDetails userDetails = User.withUsername(email).password(password)
+        .roles("COMPANY").build();
+
+    CompanyEntity companyEntity = CompanyEntity.builder()
+        .companyKey(key)
+        .build();
+
+    when(companyRepository.findByCompanyKey(key)).thenReturn(Optional.of(companyEntity));
+
+    // when
+    commonUserService.withdraw(userDetails, key);
+
+    //then
+    verify(companyRepository, times(1)).delete(companyEntity);
+    verify(companyInfoRepository, times(1)).deleteByCompanyKey(key);
+
+  }
+
+
+  @Test
+  @DisplayName("회원 탈퇴 실패 테스트 (지원자) -> KEY_NOT_MATCH")
+  void candidateWithdrawFailTest() {
+    //given
+    String email = "email";
+    String password = "password";
+    String key = "key";
+
+    UserDetails userDetails = User.withUsername(email).password(password)
+        .roles("CANDIDATE").build();
+
+    CandidateEntity candidateEntity = CandidateEntity.builder()
+        .candidateKey("key2")
+        .build();
+
+    when(candidateRepository.findByEmail(userDetails.getUsername())).thenReturn(
+        Optional.of(candidateEntity));
+
+    // when
+    CustomException customException = assertThrows(CustomException.class,
+        () -> commonUserService.withdraw(userDetails, key));
+
+    //then
+    verify(candidateRepository, times(1)).findByEmail(userDetails.getUsername());
+    assertEquals(ErrorCode.KEY_NOT_MATCH, customException.getErrorCode());
+
+  }
+
 }

--- a/src/test/java/com/ctrls/auto_enter_view/service/CommonUserServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/CommonUserServiceTest.java
@@ -552,7 +552,7 @@ class CommonUserServiceTest {
 
     UserDetails userDetails = User.withUsername(email).password(password)
         .roles("CANDIDATE").build();
-    
+
     when(candidateRepository.findByEmail(userDetails.getUsername())).thenReturn(
         Optional.empty());
 
@@ -563,6 +563,34 @@ class CommonUserServiceTest {
     //then
     verify(candidateRepository, times(1)).findByEmail(userDetails.getUsername());
     assertEquals(ErrorCode.USER_NOT_FOUND, customException.getErrorCode());
+
+  }
+
+  @Test
+  @DisplayName("회원 탈퇴 실패 테스트 (회사) -> KEY_NOT_MATCH")
+  void companyWithdrawFailTestKeyNotMatch() {
+    //given
+    String email = "email";
+    String password = "password";
+    String key = "key";
+
+    UserDetails userDetails = User.withUsername(email).password(password)
+        .roles("COMPANY").build();
+
+    CompanyEntity companyEntity = CompanyEntity.builder()
+        .companyKey("key2")
+        .build();
+
+    when(companyRepository.findByEmail(userDetails.getUsername())).thenReturn(
+        Optional.of(companyEntity));
+
+    // when
+    CustomException customException = assertThrows(CustomException.class,
+        () -> commonUserService.withdraw(userDetails, key));
+
+    //then
+    verify(companyRepository, times(1)).findByEmail(userDetails.getUsername());
+    assertEquals(ErrorCode.KEY_NOT_MATCH, customException.getErrorCode());
 
   }
 

--- a/src/test/java/com/ctrls/auto_enter_view/service/CommonUserServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/CommonUserServiceTest.java
@@ -475,7 +475,8 @@ class CommonUserServiceTest {
         .candidateKey(key)
         .build();
 
-    when(candidateRepository.findByCandidateKey(key)).thenReturn(Optional.of(candidateEntity));
+    when(candidateRepository.findByEmail(userDetails.getUsername())).thenReturn(
+        Optional.of(candidateEntity));
 
     // when
     commonUserService.withdraw(userDetails, key);
@@ -502,7 +503,8 @@ class CommonUserServiceTest {
         .companyKey(key)
         .build();
 
-    when(companyRepository.findByCompanyKey(key)).thenReturn(Optional.of(companyEntity));
+    when(companyRepository.findByEmail(userDetails.getUsername())).thenReturn(
+        Optional.of(companyEntity));
 
     // when
     commonUserService.withdraw(userDetails, key);
@@ -591,6 +593,31 @@ class CommonUserServiceTest {
     //then
     verify(companyRepository, times(1)).findByEmail(userDetails.getUsername());
     assertEquals(ErrorCode.KEY_NOT_MATCH, customException.getErrorCode());
+
+  }
+
+
+  @Test
+  @DisplayName("회원 탈퇴 실패 테스트 (회사) -> USER_NOT_FOUND")
+  void companyWithdrawFailTestUserNotFound() {
+    //given
+    String email = "email";
+    String password = "password";
+    String key = "key";
+
+    UserDetails userDetails = User.withUsername(email).password(password)
+        .roles("COMPANY").build();
+
+    when(companyRepository.findByEmail(userDetails.getUsername())).thenReturn(
+        Optional.empty());
+
+    // when
+    CustomException customException = assertThrows(CustomException.class,
+        () -> commonUserService.withdraw(userDetails, key));
+
+    //then
+    verify(companyRepository, times(1)).findByEmail(userDetails.getUsername());
+    assertEquals(ErrorCode.USER_NOT_FOUND, customException.getErrorCode());
 
   }
 

--- a/src/test/java/com/ctrls/auto_enter_view/service/CompanyServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/CompanyServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.ctrls.auto_enter_view.component.KeyGenerator;
 import com.ctrls.auto_enter_view.dto.company.SignUpDto;
 import com.ctrls.auto_enter_view.dto.company.SignUpDto.Request;
 import com.ctrls.auto_enter_view.dto.company.SignUpDto.Response;
@@ -42,6 +43,9 @@ class CompanyServiceTest {
 
   @Mock
   private SecurityContext securityContext;
+
+  @Mock
+  private KeyGenerator keyGenerator;
 
   @InjectMocks
   private CompanyService companyService;


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 회원 탈퇴 (지원자,회사) 에 대한 테스트 코드 작성 X
- CommonUserService 의 withdraw 함수에서 Entity를 가져올 때 key값을 사용

**TO-BE**
- 지원자 탈퇴 테스트 코드 작성
   - 지원자 탈퇴 성공 테스트 코드 작성
   - 지원자 탈퇴 실패 테스트 코드 작성 (KEY_NOT_MATCH 에러)
   - 지원자 탈퇴 실패 테스트 코드 작성 (USER_NOT_FOUND 에러)

- 회사 탈퇴 테스트 코드 작성
  - 회사 탈퇴 성공 테스트 코드 작성
  - 회사 탈퇴 실패 테스트 코드 작성 (KEY_NOT_MATCH 에러)
  - 회사 탈퇴 실패 테스트 코드 작성 (USER_NOT_FOUND 에러)

- CommonUserService 의 withdraw 함수에서 Entity를 가져올 때 userDetails의 getUserName으로 가져오는 방식으로 변경 (이메일로)
### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [ ] API 테스트 