### PR TITLE
채용 공고 단계 이동 시 지원자 채용 공고 조회에 stepName 업데이

### DIFF
--- a/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
@@ -8,6 +8,7 @@ import com.ctrls.auto_enter_view.dto.candidateList.CandidateTechStackInterviewIn
 import com.ctrls.auto_enter_view.dto.jobPosting.JobPostingDto;
 import com.ctrls.auto_enter_view.dto.jobPosting.JobPostingDto.Request;
 import com.ctrls.auto_enter_view.dto.jobPosting.JobPostingEveryInfoDto;
+import com.ctrls.auto_enter_view.entity.AppliedJobPostingEntity;
 import com.ctrls.auto_enter_view.entity.CandidateListEntity;
 import com.ctrls.auto_enter_view.entity.CompanyEntity;
 import com.ctrls.auto_enter_view.entity.InterviewScheduleEntity;
@@ -19,6 +20,7 @@ import com.ctrls.auto_enter_view.entity.ResumeTechStackEntity;
 import com.ctrls.auto_enter_view.enums.ErrorCode;
 import com.ctrls.auto_enter_view.enums.TechStack;
 import com.ctrls.auto_enter_view.exception.CustomException;
+import com.ctrls.auto_enter_view.repository.AppliedJobPostingRepository;
 import com.ctrls.auto_enter_view.repository.CandidateListRepository;
 import com.ctrls.auto_enter_view.repository.CompanyRepository;
 import com.ctrls.auto_enter_view.repository.InterviewScheduleParticipantsRepository;
@@ -52,7 +54,7 @@ public class JobPostingStepService {
   private final ResumeTechStackRepository resumeTechStackRepository;
   private final InterviewScheduleRepository interviewScheduleRepository;
   private final InterviewScheduleParticipantsRepository interviewScheduleParticipantsRepository;
-
+  private final AppliedJobPostingRepository appliedJobPostingRepository;
   /**
    * 채용 공고 단계 생성하기
    *
@@ -408,9 +410,21 @@ public class JobPostingStepService {
       throw new CustomException(ErrorCode.NEXT_STEP_NOT_FOUND);
     }
 
-    // 지원자의 단계 ID 업데이트
+    JobPostingStepEntity nextStep = nextStepOptional.get();
+    String nextStepName = nextStep.getStep();
+
+    // 지원자의 단계 ID 업데이트 및 AppliedJobPostingEntity의 stepName 업데이트
     for (CandidateListEntity candidate : candidateListEntities) {
       candidate.updateJobPostingStepId(nextStepId);
+
+      Optional<AppliedJobPostingEntity> appliedJobPostingOptional = appliedJobPostingRepository
+          .findByCandidateKeyAndJobPostingKey(candidate.getCandidateKey(), jobPostingKey);
+
+      if (appliedJobPostingOptional.isPresent()) {
+        AppliedJobPostingEntity appliedJobPosting = appliedJobPostingOptional.get();
+        appliedJobPosting.updateStepName(nextStepName);
+      }
     }
+
   }
 }

--- a/src/test/java/com/ctrls/auto_enter_view/service/ResumeServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/ResumeServiceTest.java
@@ -88,8 +88,6 @@ class ResumeServiceTest {
   @Mock
   private ResumeTechStackRepository resumeTechStackRepository;
 
-  @Mock private ResumeImageRepository resumeImageRepository;
-
   @Captor
   ArgumentCaptor<ResumeEntity> resumeCaptor;
 


### PR DESCRIPTION
### 변경사항

## AS-IS

- 채용 공고 단계 이동 시에 CandidateListEntity의 jobPostingStepId만 업데이트 됨


## TO-BE

- 채용 공고 단계 이동 시에 CandidateListEntity의 jobPostingStepId와 함께 AppliedJobPostingEntity의 stepName도 업데이트되도록 수정

- JobPostingStepService의 editStepId 메서드에서 AppliedJobPostingEntity를 조회하고 stepName을 업데이트하는 로직을 추가


- 채용 공고 단계 이동에 대한 테스트 코드 수정

