### PR TITLE
fix errors

### DIFF
--- a/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
@@ -76,7 +76,7 @@ public class JobPostingStepService {
    *
    * @param jobPostingKey 채용공고 KEY
    * @return 채용 단계의 모든 정보 리스트
-   * @throws CustomException USER_NOT_FOUND, JOB_POSTING_NOT_FOUND, RESUME_NOT_FOUND
+   * @throws CustomException USER_NOT_FOUND, JOB_POSTING_NOT_FOUND
    */
   @Transactional(readOnly = true)
   public List<JobPostingEveryInfoDto> getCandidatesListByStepId(UserDetails userDetails,
@@ -236,7 +236,6 @@ public class JobPostingStepService {
    *
    * @param candidateKey 지원자 PK
    * @return ResumeEntity
-   * @throws CustomException RESUME_NOT_FOUND : 이력서를 찾을 수 없는 경우
    */
   private ResumeEntity findResumeEntityByCandidateKey(String candidateKey) {
     return resumeRepository.findByCandidateKey(candidateKey)

--- a/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/JobPostingStepService.java
@@ -1,7 +1,6 @@
 package com.ctrls.auto_enter_view.service;
 
 import static com.ctrls.auto_enter_view.enums.ErrorCode.JOB_POSTING_NOT_FOUND;
-import static com.ctrls.auto_enter_view.enums.ErrorCode.RESUME_NOT_FOUND;
 import static com.ctrls.auto_enter_view.enums.ErrorCode.USER_NOT_FOUND;
 
 import com.ctrls.auto_enter_view.dto.candidateList.CandidateTechStackInterviewInfoDto;
@@ -241,7 +240,7 @@ public class JobPostingStepService {
    */
   private ResumeEntity findResumeEntityByCandidateKey(String candidateKey) {
     return resumeRepository.findByCandidateKey(candidateKey)
-        .orElseThrow(() -> new CustomException(RESUME_NOT_FOUND));
+        .orElseGet(() -> ResumeEntity.builder().build());
   }
 
   /**

--- a/src/main/java/com/ctrls/auto_enter_view/service/MailAlarmInfoService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/MailAlarmInfoService.java
@@ -20,6 +20,7 @@ import com.ctrls.auto_enter_view.entity.JobPostingEntity;
 import com.ctrls.auto_enter_view.entity.JobPostingStepEntity;
 import com.ctrls.auto_enter_view.entity.MailAlarmInfoEntity;
 import com.ctrls.auto_enter_view.exception.CustomException;
+import com.ctrls.auto_enter_view.repository.CandidateListRepository;
 import com.ctrls.auto_enter_view.repository.CandidateRepository;
 import com.ctrls.auto_enter_view.repository.CompanyRepository;
 import com.ctrls.auto_enter_view.repository.InterviewScheduleRepository;
@@ -58,6 +59,7 @@ public class MailAlarmInfoService {
   private final JobPostingRepository jobPostingRepository;
   private final JobPostingStepRepository jobPostingStepRepository;
   private final CandidateRepository candidateRepository;
+  private final CandidateListRepository candidateListRepository;
   private final MailComponent mailComponent;
   private final Scheduler scheduler;
 
@@ -344,21 +346,28 @@ public class MailAlarmInfoService {
 
     if (isTask) {
       log.info("과제일 경우 과제 취소 메일 발송");
-      for (InterviewScheduleParticipantsEntity participant : participants) {
-        String to = candidateRepository.findByCandidateKey(participant.getCandidateKey())
+
+      List<CandidateListEntity> candidateListEntities = candidateListRepository.findAllByJobPostingKeyAndJobPostingStepId(
+          interviewScheduleEntity.getJobPostingKey(),
+          interviewScheduleEntity.getJobPostingStepId());
+
+      for (CandidateListEntity candidate : candidateListEntities) {
+        String to = candidateRepository.findByCandidateKey(candidate.getCandidateKey())
             .orElseThrow(() -> new CustomException(USER_NOT_FOUND)).getEmail();
+
+        LocalDateTime scheduleDateTime = LocalDateTime.of(
+            interviewScheduleEntity.getLastInterviewDate(), LocalTime.of(23, 59, 59));
 
         String subject = "과제 취소 안내 : " + jobPostingEntity.getTitle();
         String text = "과제 일정이 <strong>취소</strong>되었음을 안내드립니다.<br><br>"
             + "취소된 과제 정보<br>" + jobPostingEntity.getTitle() + " - " + jobPostingStepEntity.getStep()
-            + "<br> 취소된 과제 마감 일시 : " + participant.getInterviewEndDatetime()
-            .format(DateTimeFormatter.ofPattern("yyyy-MM-dd EEEE HH:mm"))
-            + "<br><br>";
+            + "<br> 취소된 과제 마감 일시 : " + scheduleDateTime.format(
+            DateTimeFormatter.ofPattern("yyyy-MM-dd EEEE HH:mm")) + "<br><br>";
 
         mailComponent.sendHtmlMail(to, subject, text, true);
       }
     } else {
-      log.info("과제일 경우 면접 취소 메일 발송");
+      log.info("면접일 경우 면접 취소 메일 발송");
       for (InterviewScheduleParticipantsEntity participant : participants) {
         String to = candidateRepository.findByCandidateKey(participant.getCandidateKey())
             .orElseThrow(() -> new CustomException(USER_NOT_FOUND)).getEmail();

--- a/src/main/java/com/ctrls/auto_enter_view/service/MailAlarmInfoService.java
+++ b/src/main/java/com/ctrls/auto_enter_view/service/MailAlarmInfoService.java
@@ -136,7 +136,7 @@ public class MailAlarmInfoService {
         .mailSendDateTime(mailAlarmInfoEntity.getMailSendDateTime())
         .build();
   }
-  
+
   /**
    * 예약된 메일 수정
    *
@@ -338,8 +338,8 @@ public class MailAlarmInfoService {
             interviewScheduleEntity.getJobPostingKey())
         .orElseThrow(() -> new CustomException(JOB_POSTING_NOT_FOUND));
 
-    JobPostingStepEntity jobPostingStep = jobPostingStepRepository.findById(
-            participants.get(0).getJobPostingStepId())
+    JobPostingStepEntity jobPostingStepEntity = jobPostingStepRepository.findById(
+            interviewScheduleEntity.getJobPostingStepId())
         .orElseThrow(() -> new CustomException(JOB_POSTING_STEP_NOT_FOUND));
 
     if (isTask) {
@@ -350,7 +350,7 @@ public class MailAlarmInfoService {
 
         String subject = "과제 취소 안내 : " + jobPostingEntity.getTitle();
         String text = "과제 일정이 <strong>취소</strong>되었음을 안내드립니다.<br><br>"
-            + "취소된 과제 정보<br>" + jobPostingEntity.getTitle() + " - " + jobPostingStep.getStep()
+            + "취소된 과제 정보<br>" + jobPostingEntity.getTitle() + " - " + jobPostingStepEntity.getStep()
             + "<br> 취소된 과제 마감 일시 : " + participant.getInterviewEndDatetime()
             .format(DateTimeFormatter.ofPattern("yyyy-MM-dd EEEE HH:mm"))
             + "<br><br>";
@@ -365,7 +365,7 @@ public class MailAlarmInfoService {
 
         String subject = "면접 일정 취소 안내 : " + jobPostingEntity.getTitle();
         String text = "예정되었던 면접 일정이 <strong>취소</strong>되었음을 안내드립니다.<br><br>"
-            + "취소된 면접 정보<br>" + jobPostingEntity.getTitle() + " - " + jobPostingStep.getStep()
+            + "취소된 면접 정보<br>" + jobPostingEntity.getTitle() + " - " + jobPostingStepEntity.getStep()
             + "<br> 취소된 면접 일시 : " + participant.getInterviewStartDatetime()
             .format(DateTimeFormatter.ofPattern("yyyy-MM-dd EEEE HH:mm"));
 

--- a/src/test/java/com/ctrls/auto_enter_view/service/JobPostingStepServiceTest.java
+++ b/src/test/java/com/ctrls/auto_enter_view/service/JobPostingStepServiceTest.java
@@ -1,7 +1,6 @@
 package com.ctrls.auto_enter_view.service;
 
 import static com.ctrls.auto_enter_view.enums.ErrorCode.JOB_POSTING_NOT_FOUND;
-import static com.ctrls.auto_enter_view.enums.ErrorCode.RESUME_NOT_FOUND;
 import static com.ctrls.auto_enter_view.enums.ErrorCode.USER_NOT_FOUND;
 import static com.ctrls.auto_enter_view.enums.TechStack.JAVA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -215,56 +214,6 @@ class JobPostingStepServiceTest {
   }
 
   @Test
-  @DisplayName("채용 공고 단계별 지원자 리스트 조회 : 실패 - RESUME_NOT_FOUND")
-  void getCandidatesListByStepId_ResumeNotFoundFailure() {
-    String jobPostingKey = "jobPostingKey";
-    String companyKey = "companyKey";
-    Long stepId = 1L;
-    String candidateKey = "candidateKey";
-
-    UserDetails userDetails = mock(UserDetails.class);
-    when(userDetails.getUsername()).thenReturn("test@example.com");
-
-    JobPostingEntity jobPostingEntity = JobPostingEntity.builder()
-        .jobPostingKey(jobPostingKey)
-        .companyKey(companyKey)
-        .build();
-
-    CompanyEntity companyEntity = CompanyEntity.builder()
-        .companyKey(companyKey)
-        .email("test@example.com")
-        .build();
-
-    JobPostingStepEntity jobPostingStepEntity = JobPostingStepEntity.builder()
-        .id(stepId)
-        .jobPostingKey(jobPostingKey)
-        .step("면접 단계")
-        .build();
-
-    CandidateListEntity candidateListEntity = CandidateListEntity.builder()
-        .candidateKey(candidateKey)
-        .candidateName("John Doe")
-        .build();
-
-    when(jobPostingRepository.findByJobPostingKey(jobPostingKey))
-        .thenReturn(Optional.of(jobPostingEntity));
-    when(companyRepository.findByEmail(userDetails.getUsername()))
-        .thenReturn(Optional.of(companyEntity));
-    when(jobPostingStepRepository.findAllByJobPostingKey(jobPostingKey))
-        .thenReturn(Collections.singletonList(jobPostingStepEntity));
-    when(candidateListRepository.findAllByJobPostingKeyAndJobPostingStepId(jobPostingKey, stepId))
-        .thenReturn(Collections.singletonList(candidateListEntity));
-    when(resumeRepository.findByCandidateKey(candidateKey))
-        .thenReturn(Optional.empty());
-
-    CustomException thrownException = assertThrows(CustomException.class, () -> {
-      jobPostingStepService.getCandidatesListByStepId(userDetails, jobPostingKey);
-    });
-
-    assertEquals(RESUME_NOT_FOUND, thrownException.getErrorCode());
-  }
-
-  @Test
   @DisplayName("채용 단계 올리기 테스트 - 성공")
   void editStepIdSuccessTest() {
     // given
@@ -350,7 +299,8 @@ class JobPostingStepServiceTest {
         .companyKey(companyKey)
         .jobPostingKey(jobPostingKey)
         .build();
-    when(jobPostingRepository.findByJobPostingKey(jobPostingKey)).thenReturn(Optional.of(jobPostingEntity));
+    when(jobPostingRepository.findByJobPostingKey(jobPostingKey)).thenReturn(
+        Optional.of(jobPostingEntity));
 
     List<CandidateListEntity> candidateListEntities = new ArrayList<>();
     for (String candidateKey : candidateKeys) {
@@ -361,7 +311,8 @@ class JobPostingStepServiceTest {
           .build();
       candidateListEntities.add(candidateListEntity);
     }
-    when(candidateListRepository.findAllByCandidateKeyInAndJobPostingKey(candidateKeys, jobPostingKey)).thenReturn(candidateListEntities);
+    when(candidateListRepository.findAllByCandidateKeyInAndJobPostingKey(candidateKeys,
+        jobPostingKey)).thenReturn(candidateListEntities);
 
     UserDetails userDetails = org.springframework.security.core.userdetails.User.builder()
         .username(companyEmail)
@@ -378,7 +329,8 @@ class JobPostingStepServiceTest {
     assertEquals(ErrorCode.INVALID_CURRENT_STEP_ID, exception.getErrorCode());
     verify(companyRepository).findByEmail(companyEmail);
     verify(jobPostingRepository).findByJobPostingKey(jobPostingKey);
-    verify(candidateListRepository).findAllByCandidateKeyInAndJobPostingKey(candidateKeys, jobPostingKey);
+    verify(candidateListRepository).findAllByCandidateKeyInAndJobPostingKey(candidateKeys,
+        jobPostingKey);
   }
 
   @Test
@@ -527,7 +479,8 @@ class JobPostingStepServiceTest {
             .jobPostingStepId(currentStepId)
             .build())
         .collect(Collectors.toList());
-    when(candidateListRepository.findAllByCandidateKeyInAndJobPostingKey(candidateKeys, jobPostingKey))
+    when(candidateListRepository.findAllByCandidateKeyInAndJobPostingKey(candidateKeys,
+        jobPostingKey))
         .thenReturn(candidateListEntities);
 
     Long nextStepId = currentStepId + 1;


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 단계별 전체 지원자 목록 조회 시 지원자 한 명이라도 이력서가 없다면 조회 전체가 되지 않는 오류
- 과제 일정 삭제 시 `index 0 out of bounds for length 0` 에러 발생
  - List가 size가 0인데도 불구하고 0번째 인덱스를 get하려 해서 생기는 문제 
- 일정 취소 메일 발송 시 과제 일정에 대한 로직 문제
  - 과제 일정일 경우 InterviewScheduleParticipant 엔티티들을 저장하지 않기에 InterviewScheduleParticipant 목록을 찾아서 취소 메일을 보내는 것은 적절치 않음 (한 사람도 찾지 못할 것)

**TO-BE**
- 단계별 전체 지원자 목록 조회 시 이력서가 없는 지원자라면 RESUME_NOT_FOUND 에러 대신 resumeKey에 null값이 return되도록 수정
  - RESUME_NOT_FOUND로 인한 실패 테스트 삭제
- 과제 일정 삭제 시 List가 아닌 interviewScheduleEntity에서 stepId 값을 찾아오도록 수정
- 일정 취소 메일 발송 시 과제 일정에 대한 로직 수정
  - 과제 일정일 경우 CandidateList 목록을 찾아서 취소 메일을 보내도록 수정함

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [X] 테스트 코드